### PR TITLE
New configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Then fill it with your data. Below are the available configuration options:
 - `config.api_path`: Sets the API path if your API is under a different namespace.
 - `config.ignored_actions`: Sets an array with the controller or controller#action. No necessary to add api_path before.
 - `config.http_verbs`: Defaults to `[:get, :post, :put, :patch, :delete]`
+- `config.use_model_names`: Use model names when possible, defaults to `false`
 
 ### Authentication Settings
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Then fill it with your data. Below are the available configuration options:
 - `config.autodiscover_responses`: Automatically detects responses from controller renders. Default is `true`.
 - `config.api_path`: Sets the API path if your API is under a different namespace.
 - `config.ignored_actions`: Sets an array with the controller or controller#action. No necessary to add api_path before.
+- `config.http_verbs`: Defaults to `[:get, :post, :put, :patch, :delete]`
 
 ### Authentication Settings
 

--- a/lib/oas_rails/configuration.rb
+++ b/lib/oas_rails/configuration.rb
@@ -11,7 +11,8 @@ module OasRails
                   :authenticate_all_routes_by_default,
                   :set_default_responses,
                   :possible_default_responses,
-                  :response_body_of_default
+                  :response_body_of_default,
+                  :http_verbs
     attr_reader :servers, :tags, :security_schema
 
     def initialize
@@ -30,6 +31,7 @@ module OasRails
       @security_schemas = {}
       @set_default_responses = true
       @possible_default_responses = [:not_found, :unauthorized, :forbidden]
+      @http_verbs = [:get, :post, :put, :patch, :delete]
       @response_body_of_default = "Hash{ success: !Boolean, message: String }"
     end
 

--- a/lib/oas_rails/configuration.rb
+++ b/lib/oas_rails/configuration.rb
@@ -12,7 +12,8 @@ module OasRails
                   :set_default_responses,
                   :possible_default_responses,
                   :response_body_of_default,
-                  :http_verbs
+                  :http_verbs,
+                  :use_model_names
     attr_reader :servers, :tags, :security_schema
 
     def initialize
@@ -33,6 +34,7 @@ module OasRails
       @possible_default_responses = [:not_found, :unauthorized, :forbidden]
       @http_verbs = [:get, :post, :put, :patch, :delete]
       @response_body_of_default = "Hash{ success: !Boolean, message: String }"
+      @use_model_names = false
     end
 
     def security_schema=(value)

--- a/lib/oas_rails/spec/components.rb
+++ b/lib/oas_rails/spec/components.rb
@@ -44,9 +44,20 @@ module OasRails
       end
 
       def add_schema(schema)
-        key = Hashable.generate_hash(schema)
-        @schemas[key] = schema if @schemas[key].nil?
+        key = nil
+        if OasRails.config.use_model_names
+          if schema[:type] == 'array'
+            arr_schema = schema[:items]
+            arr_key = arr_schema['title']
+            key = "#{arr_key}List" unless arr_key.nil?
+          else
+            key = schema['title']
+          end
+        end
 
+        key = Hashable.generate_hash(schema) if key.nil?
+
+        @schemas[key] = schema if @schemas[key].nil?
         schema_reference(key)
       end
 

--- a/lib/oas_rails/spec/path_item.rb
+++ b/lib/oas_rails/spec/path_item.rb
@@ -26,7 +26,7 @@ module OasRails
       end
 
       def oas_fields
-        [:get, :post, :put, :patch, :delete]
+        OasRails.config.http_verbs
       end
     end
   end


### PR DESCRIPTION
Two new options have been added (with default settings that preserve the current behavior)

- `config.http_verbs`: Defaults to `[:get, :post, :put, :patch, :delete]`
- `config.use_model_names`: Use model names when possible, defaults to `false`

The reason for `http_verbs` is that I want to be able to exclude `PUT` and only use `PATCH` for updates . The reason for `use_model_names` is to avoid getting new type names if the model changes its attributes in the generated client code (generate hash name).