### PR TITLE
Allow it to be used without ActiveRecord being present

### DIFF
--- a/lib/oas_rails/builders/content_builder.rb
+++ b/lib/oas_rails/builders/content_builder.rb
@@ -33,7 +33,7 @@ module OasRails
       end
 
       def from_model_class(klass)
-        return self unless klass.ancestors.include? ActiveRecord::Base
+        return self unless klass.ancestors.map(&:to_s).include? 'ActiveRecord::Base'
 
         model_schema = Builders::EsquemaBuilder.send("build_#{@context}_schema", klass:)
         model_schema["required"] = []

--- a/lib/oas_rails/builders/request_body_builder.rb
+++ b/lib/oas_rails/builders/request_body_builder.rb
@@ -18,7 +18,7 @@ module OasRails
       end
 
       def from_tags(tag:, examples_tags: [])
-        if tag.klass.ancestors.include? ActiveRecord::Base
+        if tag.klass.ancestors.map(&:to_s).include? 'ActiveRecord::Base'
           from_model_class(klass: tag.klass, description: tag.text, required: tag.required, examples_tags:)
         else
           @request_body.description = tag.text

--- a/lib/oas_rails/extractors/render_response_extractor.rb
+++ b/lib/oas_rails/extractors/render_response_extractor.rb
@@ -60,7 +60,7 @@ module OasRails
           maybe_a_model, errors = content.gsub('@', "").split(".")
           klass = maybe_a_model.singularize.camelize(:upper).constantize
 
-          if klass.ancestors.include?(ActiveRecord::Base)
+          if klass.ancestors.map(&:to_s).include? 'ActiveRecord::Base'
             schema = Builders::EsquemaBuilder.build_outgoing_schema(klass:)
             if test_singularity(maybe_a_model)
               build_singular_model_schema_and_examples(maybe_a_model, errors, klass, schema)

--- a/lib/oas_rails/yard/oas_rails_factory.rb
+++ b/lib/oas_rails/yard/oas_rails_factory.rb
@@ -151,7 +151,7 @@ module OasRails
       # @return [Boolean] True if the text refers to an ActiveRecord class, false otherwise.
       def active_record_class?(text)
         klass = text.constantize
-        klass.ancestors.include? ActiveRecord::Base
+        klass.ancestors.map(&:to_s).include? 'ActiveRecord::Base'
       rescue StandardError
         false
       end


### PR DESCRIPTION
When you use `include? ActiveRecord::Base`, you expect that module/class to be loaded. Changed the verification to use a text representation of the module