### PR TITLE
fix error when fixture has erb

### DIFF
--- a/lib/oas_rails/spec/media_type.rb
+++ b/lib/oas_rails/spec/media_type.rb
@@ -1,3 +1,4 @@
+include 'erb'
 module OasRails
   module Spec
     class MediaType
@@ -68,7 +69,11 @@ module OasRails
         def fetch_fixture_examples(klass:)
           fixture_file = Rails.root.join('test', 'fixtures', "#{klass.to_s.pluralize.downcase}.yml")
           begin
-            fixture_data = YAML.load_file(fixture_file).with_indifferent_access
+            erb_result = ERB.new(File.read(fixture_file)).result
+            fixture_data = YAML.safe_load(
+              erb_result,
+              permitted_classes: [Symbol, ActiveSupport::HashWithIndifferentAccess]
+            ).with_indifferent_access
           rescue Errno::ENOENT
             return {}
           end


### PR DESCRIPTION

my `/test/fixtures/users.yml` file which has erb makes it break.

```
<% password_digest = BCrypt::Password.create("password") %>

one:
  email_address: one@example.com
  password_digest: <%= password_digest %>

two:
  email_address: two@example.com
  password_digest: <%= password_digest %>
```

after making this change it works again
