### PR TITLE
feat: add support for multiline tag definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 OasRails is a Rails engine for generating **automatic interactive documentation for your Rails APIs**. It generates an **OAS 3.1** document and displays it using **[RapiDoc](https://rapidocweb.com)**.
 
 🎬 A Demo Video Here:
-https://vimeo.com/1013687332
+<https://vimeo.com/1013687332>
 🎬
 
 ![Screenshot](https://a-chacon.com/assets/images/oas_rails_ui.png)
@@ -80,7 +80,7 @@ You'll now have **basic documentation** based on your routes and automatically g
 
 ## ⚙️ Configuration
 
-To configure OasRails, you MUST create an initializer file including all your settings. The first step is to create your initializer file, which you can easily do with:
+To configure OasRails, **you MUST create an initializer file** including all your settings. The first step is to create your initializer file, which you can easily do with:
 
 ```bash
 rails generate oas_rails:config
@@ -135,7 +135,20 @@ In addition to the information provided in the initializer file and the data tha
 
 ### Documenting Your Endpoints
 
-Almost every description in an OAS file supports simple markdown. The following tags are available for documenting your endpoints:
+Almost every tag description in an OAS file supports **markdown formatting** (e.g., bold, italics, lists, links) for better readability in the generated documentation. Additionally, **multi-line descriptions** are supported. When using multi-line descriptions, ensure the content is indented at least one space more than the tag itself to maintain proper formatting.
+
+For example:
+
+```ruby
+  # @request_body_example Simple User [Hash]
+  #   {
+  #     user: {
+  #       name: "Oas",
+  #       email: "oas@test.com",
+  #       password: "Test12345"
+  #     }
+  #   }
+```
 
 <details>
 <summary style="font-weight: bold; font-size: 1.2em;">@summary</summary>
@@ -145,7 +158,13 @@ Almost every description in an OAS file supports simple markdown. The following 
 Used to add a summary to the endpoint. It replaces the default summary/title of the endpoint.
 
 **Example**:
+
 `# @summary This endpoint creates a User`
+
+```
+# @summary This endpoint
+#   creates a User
+```
 
 </details>
 
@@ -169,15 +188,31 @@ Represents a parameter for the endpoint. The position can be: `header`, `path`, 
 
 Documents the request body needed by the endpoint. The structure is optional if you provide a valid Active Record class. Use `!` to indicate a required request body.
 
-**Example**:
-
-`# @request_body The user to be created [!Hash{user: Hash{name: String, age: Integer, password: String}}]`
+**One line example**:
 
 `# @request_body The user to be created [!User]`
 
 `# @request_body The user to be created [User]`
 
-`# @request_body The user to be created [!Hash{user: Hash{name: String, age: Integer, password: String, surnames: Array<String>, coords: Hash{lat: String, lng: String}}}]`
+**Multi-line example**:
+
+```ruby
+  # @request_body User to be created
+  #   [
+  #     !Hash{
+  #       user: Hash{
+  #         name: String,
+  #         email: String,
+  #         age: Integer,
+  #         cars: Array<
+  #           Hash{
+  #             identifier: String
+  #           }
+  #         >
+  #       }
+  #     }
+  #   ]
+```
 
 </details>
 
@@ -188,8 +223,22 @@ Documents the request body needed by the endpoint. The structure is optional if 
 
 Adds examples to the provided request body.
 
-**Example**:
+**One line example**:
+
 `# @request_body_example A complete User. [Hash] {user: {name: 'Luis', age: 30, password: 'MyWeakPassword123'}}`
+
+**Multi-line example**:
+
+```ruby
+  # @request_body_example basic user [Hash]
+  #   {
+  #     user: {
+  #       name: "Oas",
+  #       email: "oas@test.com",
+  #       password: "Test12345"
+  #     }
+  #   }
+```
 
 </details>
 
@@ -200,11 +249,26 @@ Adds examples to the provided request body.
 
 Documents the responses of the endpoint and overrides the default responses found by the engine.
 
-**Example**:
+**One line example**:
 
 `# @response User not found by the provided Id(404) [Hash{success: Boolean, message: String}]`
 
 `# @response Validation errors(422) [Hash{success: Boolean, errors: Array<Hash{field: String, type: String, detail: Array<String>}>}]`
+
+**Multi-line example**:
+
+```ruby
+  # @response A test response from an Issue(405)
+  #   [
+  #     Hash{
+  #       message: String,
+  #       data: Hash{
+  #         availabilities: Array<String>,
+  #         dates: Array<Date>
+  #       }
+  #     }
+  #   ]
+```
 
 </details>
 
@@ -215,11 +279,26 @@ Documents the responses of the endpoint and overrides the default responses foun
 
 Documents response examples of the endpoint associated to a response code.
 
-**Example**:
+**One line example**:
 
 `# @response_example Invalida Email(422) [{success: "false", errors: [{field: "email", type: "email", detail: ["Invalid email"]}] }]`
 
 `# @response_example Id not exists (404) [{success: "false", message: "Nothing found with the provided ID." }]`
+
+**Multi-line example**:
+
+```ruby
+  # @response_example Another 405 Error (405) [Hash]
+  #   {
+  #     message: "another",
+  #     data: {
+  #       availabilities: [
+  #         "three"
+  #       ],
+  #       dates: []
+  #     }
+  #   }
+```
 
 </details>
 
@@ -282,9 +361,9 @@ class UsersController < ApplicationController
   # This method show a User by ID. The id must exist of other way it will be returning a **`404`**.
   #
   # @parameter id(path) [Integer] Used for identify the user.
-  # @response Requested User(200) [Hash{user: {name: String, email: String, created_at: DateTime }}]
-  # @response User not found by the provided Id(404) [Hash{success: Boolean, message: String}]
-  # @response You don't have the right permission for access to this resource(403) [Hash{success: Boolean, message: String}]
+  # @response Requested User(200) [Hash] {user: {name: String, email: String, created_at: DateTime }}
+  # @response User not found by the provided Id(404) [Hash] {success: Boolean, message: String}
+  # @response You don't have the right permission for access to this resource(403) [Hash] {success: Boolean, message: String}
   def show
     render json: @user
   end
@@ -409,6 +488,8 @@ Once the custom view file is in place, Rails will automatically use it instead o
 
 Contributions are what make the open source community such an amazing place to learn, inspire, and create. Any contributions you make are **greatly appreciated**. If you have a suggestion that would make this better, please fork the repo and create a pull request. You can also simply open an issue with the tag "enhancement". Don't forget to give the project a star⭐! Thanks again!
 
+If you plan a big feature, first open an issue to discuss it before any development.
+
 1. Fork the Project
 2. Create your Feature Branch (`git checkout -b feature/AmazingFeature`)
 3. Commit your Changes (`git commit -m 'Add some AmazingFeature'`)
@@ -417,14 +498,14 @@ Contributions are what make the open source community such an amazing place to l
 
 ### Roadmap and Ideas for Improvement
 
-- Clean, document and structure the code
+- [ ] Clean, document and structure the code
 - [x] Support documentation of authentication methods
-- Define Global Tags/Configuration (e.g., common responses like 404 errors)
-- Post-process the JSON and replace common objects with references to components
-- Create a temporary file with the JSON in production mode to avoid rebuilding it on every request
-- Create tags for popular gems used in APIs (e.g., a `@pagy` tag for common pagination parameters)
+- [ ] Define Global Tags/Configuration (e.g., common responses like 404 errors)
+- [ ] Post-process the JSON and replace common objects with references to components
+- [ ] Create a temporary file with the JSON in production mode to avoid rebuilding it on every request
+- [ ] Create tags for popular gems used in APIs (e.g., a `@pagy` tag for common pagination parameters)
 - [x] Add basic authentication to OAS and UI for security reasons (Solution documented, not need to be managed by the engine)
-- Implement ability to define OAS by namespaces (e.g., generate OAS for specific routes like `/api` or separate versions V1 and V2)
+- [ ] Implement ability to define OAS by namespaces (e.g., generate OAS for specific routes like `/api` or separate versions V1 and V2)
 
 ## License
 

--- a/lib/oas_rails/oas_route.rb
+++ b/lib/oas_rails/oas_route.rb
@@ -25,9 +25,11 @@ module OasRails
     end
 
     def extract_docstring
-      ::YARD::Docstring.parser.parse(
-        controller_class.constantize.instance_method(method).comment.lines.map { |line| line.sub(/^#\s*/, '') }.join
-      ).to_docstring
+      comment_lines = controller_class.constantize.instance_method(method).comment.lines
+      processed_lines = comment_lines.map do |line|
+        line.sub(/^# /, '')
+      end
+      ::YARD::Docstring.parser.parse(processed_lines.join).to_docstring
     end
 
     def extract_source_string

--- a/lib/oas_rails/yard/oas_rails_factory.rb
+++ b/lib/oas_rails/yard/oas_rails_factory.rb
@@ -6,7 +6,7 @@ module OasRails
       # @param text [String] The tag text to parse.
       # @return [RequestBodyTag] The parsed request body tag object.
       def parse_tag_with_request_body(tag_name, text)
-        description, klass, schema, required = extract_description_and_schema(text)
+        description, klass, schema, required = extract_description_and_schema(text.squish)
         RequestBodyTag.new(tag_name, description, klass, schema:, required:)
       end
 
@@ -15,7 +15,7 @@ module OasRails
       # @param text [String] The tag text to parse.
       # @return [RequestBodyExampleTag] The parsed request body example tag object.
       def parse_tag_with_request_body_example(tag_name, text)
-        description, _, hash = extract_description_type_and_content(text, process_content: true, expresion: /^(.*?)\[([^\]]*)\](.*)$/m)
+        description, _, hash = extract_description_type_and_content(text.squish, process_content: true, expresion: /^(.*?)\[([^\]]*)\](.*)$/m)
         RequestBodyExampleTag.new(tag_name, description, content: hash)
       end
 
@@ -24,7 +24,7 @@ module OasRails
       # @param text [String] The tag text to parse.
       # @return [ParameterTag] The parsed parameter tag object.
       def parse_tag_with_parameter(tag_name, text)
-        name, location, schema, required, description = extract_name_location_schema_and_description(text)
+        name, location, schema, required, description = extract_name_location_schema_and_description(text.squish)
         name = "#{name}[]" if location == "query" && schema[:type] == "array"
         ParameterTag.new(tag_name, name, description, schema, location, required:)
       end
@@ -34,7 +34,7 @@ module OasRails
       # @param text [String] The tag text to parse.
       # @return [ResponseTag] The parsed response tag object.
       def parse_tag_with_response(tag_name, text)
-        name, code, schema = extract_name_code_and_schema(text)
+        name, code, schema = extract_name_code_and_schema(text.squish)
         ResponseTag.new(tag_name, code, name, schema)
       end
 
@@ -43,7 +43,7 @@ module OasRails
       # @param text [String] The tag text to parse.
       # @return [ResponseExampleTag] The parsed response example tag object.
       def parse_tag_with_response_example(tag_name, text)
-        description, code, hash = extract_name_code_and_hash(text)
+        description, code, hash = extract_name_code_and_hash(text.squish)
         ResponseExampleTag.new(tag_name, description, content: hash, code:)
       end
 
@@ -99,8 +99,8 @@ module OasRails
       # @return [Array] An array containing the name, code, and schema.
       def extract_name_code_and_hash(text)
         name, code = extract_text_and_parentheses_content(text)
-        _, type, = extract_description_type_and_content(text)
-        hash = eval_content(type)
+        _, _, content = extract_description_type_and_content(text, expresion: /^(.*?)\[([^\]]*)\](.*)$/m)
+        hash = eval_content(content)
         [name, code, hash]
       end
 

--- a/test/dummy/app/controllers/users_controller.rb
+++ b/test/dummy/app/controllers/users_controller.rb
@@ -44,9 +44,28 @@ class UsersController < ApplicationController
   # @response A nice user(200) [Hash{user: Hash{name: String, email: String, created_at: DateTime }}]
   # @response User not found by the provided Id(404) [Hash{success: Boolean, message: String}]
   # @response You dont have the rigth persmissions for access to this reasource(403) [Hash{success: Boolean, message: String}]
-  # @response A test response from an Issue(405) [Hash{message: String, data: Hash{availabilities: Array<String>, dates: Array<Date>}}]
-  # @response_example Nice 405 Error(405) [{message: "Hello", data: {availabilities: ["one", "two", "three"], dates: ["10-06-2020"]}}]
-  # @response_example Another 405 Error (405) [{message: "another", data: {availabilities: ["three"], dates: []}}]
+  # @response A test response from an Issue(405)
+  #   [
+  #     Hash{
+  #       message: String,
+  #       data: Hash{
+  #         availabilities: Array<String>,
+  #         dates: Array<Date>
+  #       }
+  #     }
+  #   ]
+  # @response_example Nice 405 Error(405) [Hash]
+  #   {message: "Hello", data: {availabilities: ["one", "two", "three"], dates: ["10-06-2020"]}}
+  # @response_example Another 405 Error (405) [Hash]
+  #   {
+  #     message: "another",
+  #     data: {
+  #       availabilities: [
+  #         "three"
+  #       ],
+  #       dates: []
+  #     }
+  #   }
   def show
     render json: @user
   end
@@ -58,7 +77,14 @@ class UsersController < ApplicationController
   # The value is set per-request as shown in the adjacent code sample. Methods on the returned object reuse the same account ID.ased on the strings
   #
   # @request_body The user to be created. At least include an `email`. [!User]
-  # @request_body_example basic user [Hash] {user: {name: "Oas", email: "oas@test.com", password: "Test12345"}}
+  # @request_body_example basic user [Hash]
+  #   {
+  #     user: {
+  #       name: "Oas",
+  #       email: "oas@test.com",
+  #       password: "Test12345"
+  #     }
+  #   }
   def create
     @user = User.new(user_params)
 
@@ -73,7 +99,21 @@ class UsersController < ApplicationController
   # A `user` can be updated with this method
   # - There is no option
   # - It must work
-  # @request_body User to be created [!Hash{user: Hash{ name: String, email: String, age: Integer, cars: Array<Hash{identifier: String}>}}]
+  # @request_body User to be created
+  #   [
+  #     !Hash{
+  #       user: Hash{
+  #         name: String,
+  #         email: String,
+  #         age: Integer,
+  #         cars: Array<
+  #           Hash{
+  #             identifier: String
+  #           }
+  #         >
+  #       }
+  #     }
+  #   ]
   # @request_body_example Update user [Hash] {user: {name: "Luis", email: "luis@gmail.com"}}
   # @request_body_example Complete User [Hash] {user: {name: "Luis", email: "luis@gmail.com", age: 21}}
   def update

--- a/test/lib/oas_rails/yard/oas_rails_factory_test.rb
+++ b/test/lib/oas_rails/yard/oas_rails_factory_test.rb
@@ -5,7 +5,7 @@ module OasRails
     class OasRailsFactoryTest < ActiveSupport::TestCase
       def test_parse_tag_with_response_example
         response = OasRailsFactory.new.parse_tag_with_response_example(:response_example,
-                                                                       '405 Error(405) [{message: "Hello", data: {availabilities: ["one", "two", "three"], dates: ["10-06-2020"]}}]')
+                                                                       '405 Error(405) [Hash] {message: "Hello", data: {availabilities: ["one", "two", "three"], dates: ["10-06-2020"]}}')
 
         assert response.is_a?(ResponseExampleTag)
         assert_equal "405", response.code

--- a/test/yard/oas_rails_factory_test.rb
+++ b/test/yard/oas_rails_factory_test.rb
@@ -51,7 +51,7 @@ module OasRails
       end
 
       test 'parse_tag_with_response_example returns ResponseExampleTag' do
-        text = 'Invalid Email(422) [{success: "false", errors: [{field: "email", type: "email", detail: ["Invalid email"]}] }]'
+        text = 'Invalid Email(422) [Hash] {success: "false", errors: [{field: "email", type: "email", detail: ["Invalid email"]}] }'
         tag = @factory.parse_tag_with_response_example('response_example', text)
         assert_instance_of ResponseExampleTag, tag
         assert_equal 'Invalid Email', tag.text


### PR DESCRIPTION
## Add support for multiline examples in request body and response documentation

### Purpose

This PR enhances OAS Rails by adding proper support for multiline examples **in any tag.**
This allows developers to document complex JSON structures in a more readable and maintainable format.

### Problem

Previously, the gem could only properly parse single-line examples. When attempting to use multiline examples with complex nested structures, the parser would fail to capture the content correctly, resulting in nil values for example content.

### Usage

Developers can now document complex request and response examples in a more readable format:
Single-line (still supported):
```ruby
# @response_example Success(200) [Hash] {id: 123, name: "Product"}
```
Multiline (new format):
```ruby
# @response_example Complex Response(200) [Hash] 
#  {
#   user: {
#     name: "John Doe",
#     email: "john@example.com",
#     addresses: [
#       { street: "123 Main St", city: "San Francisco" }
#     ]
#   }
#  }
```