### PR TITLE
feat: add include_mode for handle what include in final oas

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -22,4 +22,11 @@
   - [@tag](tags/tag.md)
   - [@no_auth](tags/no_auth.md)
   - [@auth](tags/auth.md)
+  - [@oas_include](tags/oas_include.md)
 - [Examples](examples.md)
+
+---
+
+# Others
+
+- [Friendly LLMs Docs (llmstxt)](llmstxt.md)

--- a/docs/src/configuration/README.md
+++ b/docs/src/configuration/README.md
@@ -11,10 +11,15 @@ Then fill it with your data. Below are the available configuration options:
 ### Basic Information about the API
 
 - `config.info.title`: The title of your API documentation.
+
 - `config.info.summary`: A brief summary of your API.
+
 - `config.info.description`: A detailed description of your API. This can include markdown formatting and will be displayed prominently in your documentation.
+
 - `config.info.contact.name`: The name of the contact person or organization.
+
 - `config.info.contact.email`: The contact email address.
+
 - `config.info.contact.url`: The URL for more information or support.
 
 ### Servers Information
@@ -27,18 +32,69 @@ Then fill it with your data. Below are the available configuration options:
 
 ### Optional Settings
 
-- `config.default_tags_from`: Determines the source of default tags for operations. Can be set to `:namespace` or `:controller`.
+- `config.include_mode`: Determines the mode for including operations. The default value is `all`, which means it will include all route operations under the `api_path`, whether documented or not. Other possible values:
+  - `:with_tags`: Includes in your OAS only the operations with at least one tag. Example:
+
+    Not included:
+
+    ```ruby
+    def update
+    end
+    ```
+
+    Included:
+
+    ```ruby
+    # @summary Return all Books
+    def index
+    end
+    ```
+
+  - `:explicit`: Includes in your OAS only the operations tagged with `@oas_include`. Example:
+
+    Not included:
+
+    ```ruby
+    def update
+    end
+    ```
+
+    Included:
+
+    ```ruby
+    # @oas_include
+    def index
+    end
+    ```
+
+- `config.api_path`: Sets the API path if your API is under a different namespace than the root. This is important to configure if you have the `include_mode` set to `all` because it will include all routes of your app in the final OAS. For example, if your app has additional routes and your API is under the namespace `/api`, set this configuration as follows:
+
+  ```ruby
+  config.api_path = "/api"
+  ```
+
+- `config.ignored_actions`: Defines an array of controller or controller#action pairs. You do not need to prepend the `api_path`. This is useful when you want to include all routes except a few specific actions or when an external engine (e.g., Devise) adds routes to your API.
+
+- `config.default_tags_from`: Determines the source of default tags for operations. Can be set to `:namespace` or `:controller`. The first option means that if your endpoint is in the route `/users/:id`, it will be tagged with `Users`. If set to `controller`, the tag will be `UsersController`.
+
 - `config.autodiscover_request_body`: Automatically detects request bodies for create/update methods. Default is `true`.
 - `config.autodiscover_responses`: Automatically detects responses from controller renders. Default is `true`.
-- `config.api_path`: Sets the API path if your API is under a different namespace.
-- `config.ignored_actions`: Sets an array with the controller or controller#action. No necessary to add api_path before.
 - `config.http_verbs`: Defaults to `[:get, :post, :put, :patch, :delete]`
 - `config.use_model_names`: Use model names when possible, defaults to `false`
 
 ### Authentication Settings
 
 - `config.authenticate_all_routes_by_default`: Determines whether to authenticate all routes by default. Default is `true`.
-- `config.security_schema`: The default security schema used for authentication. Choose a predefined security schema from `[:api_key_cookie, :api_key_header, :api_key_query, :basic, :bearer, :bearer_jwt, :mutual_tls]`.
+
+- `config.security_schema`: The default security schema used for authentication. Choose from the following predefined options:
+  - `:api_key_cookie`: API key passed via HTTP cookie.
+  - `:api_key_header`: API key passed via HTTP header.
+  - `:api_key_query`: API key passed via URL query parameter.
+  - `:basic`: HTTP Basic Authentication.
+  - `:bearer`: Bearer token (generic).
+  - `:bearer_jwt`: Bearer token formatted as a JWT (JSON Web Token).
+  - `:mutual_tls`: Mutual TLS authentication (mTLS).
+
 - `config.security_schemas`: Custom security schemas. Follow the [OpenAPI Specification](https://spec.openapis.org/oas/latest.html#security-scheme-object) for defining these schemas.
 
 ### Default Errors
@@ -52,4 +108,5 @@ Then fill it with your data. Below are the available configuration options:
 ### Project License
 
 - `config.info.license.name`: The title name of your project's license. Default: GPL 3.0
+
 - `config.info.license.url`: The URL to the full license text. Default: <https://www.gnu.org/licenses/gpl-3.0.html#license-text>

--- a/docs/src/llmstxt.md
+++ b/docs/src/llmstxt.md
@@ -1,0 +1,29 @@
+# LLMs Documentation (llms.txt)
+
+OasRails generates `.txt` files optimized for AI integration:
+
+- [llms.txt](/llms.txt): Provides the basics to understand the structure and functionality of OasRails. (Work in progress)
+- [llms-full.txt](/llms-full.txt): Offers a full description of how to use OasRails and document endpoints. (**Currently recommended**)
+
+## How It Works (in 3 Steps)
+
+### 1. Choose the File
+
+OasRails generates `.txt` files optimized for AI tools.
+
+### 2. Load It Into Your Tool
+
+You can load these files into any AI tool or editor that supports external context. For this example, I used Cursor. **This is not a tool I recommend** because it is closed-source, but it worked for the example.
+
+<video controls>
+  <source src="https://a-chacon.com/assets/images/cursor+oasrails.mp4" type="video/mp4">
+  Your browser does not support the video tag.
+</video>
+
+### 3. Ask Questions Naturally
+
+Examples of questions you can ask:
+
+- *"How to document JWT authentication in OasRails?"*  
+- *"Document the endpoint..."*  
+- *"Add examples of possible request bodies for the create method."*

--- a/docs/src/tags/oas_include.md
+++ b/docs/src/tags/oas_include.md
@@ -1,0 +1,22 @@
+# @oas_include
+
+Use this tag to explicitly include endpoints in the final OpenAPI Specification (OAS) file **when `include_mode` is set to `:explicit`**. Only endpoints annotated with `@oas_include` will be included.
+
+## Usage
+
+Add the `@oas_include` tag as a comment above the endpoint you want to document. For example:
+
+### Endpoint Not Included (Default Behavior)
+
+```ruby
+def update
+end
+```
+
+### Endpoint Included (With `@oas_include`)
+
+```ruby
+# @oas_include
+def index
+end
+```

--- a/lib/oas_rails.rb
+++ b/lib/oas_rails.rb
@@ -90,7 +90,8 @@ module OasRails
         'Endpoint Tags' => [:tags],
         'Summary' => [:summary],
         'No Auth' => [:no_auth],
-        'Auth methods' => [:auth, :with_types]
+        'Auth methods' => [:auth, :with_types],
+        'OAS Include' => [:oas_include]
       }
       yard_tags.each do |tag_name, (method_name, handler)|
         ::YARD::Tags::Library.define_tag(tag_name, method_name, handler)

--- a/lib/oas_rails/configuration.rb
+++ b/lib/oas_rails/configuration.rb
@@ -15,7 +15,8 @@ module OasRails
                   :http_verbs,
                   :use_model_names,
                   :rapidoc_theme
-    attr_reader :servers, :tags, :security_schema
+
+    attr_reader :servers, :tags, :security_schema, :include_mode
 
     def initialize
       @info = Spec::Info.new
@@ -37,6 +38,7 @@ module OasRails
       @response_body_of_default = "Hash{ success: !Boolean, message: String }"
       @use_model_names = false
       @rapidoc_theme = :rails
+      @include_mode = :all
     end
 
     def security_schema=(value)
@@ -63,6 +65,13 @@ module OasRails
 
     def excluded_columns_outgoing
       []
+    end
+
+    def include_mode=(value)
+      valid_modes = [:all, :with_tags, :explicit]
+      raise ArgumentError, "include_mode must be one of #{valid_modes}" unless valid_modes.include?(value)
+
+      @include_mode = value
     end
   end
 

--- a/test/dummy/app/controllers/users_controller.rb
+++ b/test/dummy/app/controllers/users_controller.rb
@@ -127,6 +127,7 @@ class UsersController < ApplicationController
   end
 
   # DELETE /users/1
+  # @oas_include
   def destroy
     @user.destroy!
     redirect_to users_url, notice: 'User was successfully destroyed.', status: :see_other

--- a/test/lib/oas_rails/extractors/route_extractor_test.rb
+++ b/test/lib/oas_rails/extractors/route_extractor_test.rb
@@ -1,34 +1,48 @@
 module OasRails
   module Builders
     class RouteExtractorTest < Minitest::Test
-      def test_without_custom_routes
+      def setup
         Extractors::RouteExtractor.clear_cache
         OasRails.config.ignored_actions = []
+        OasRails.config.include_mode = :all
+      end
+
+      def teardown
+        Extractors::RouteExtractor.clear_cache
+        OasRails.config.ignored_actions = []
+        OasRails.config.include_mode = :all
+      end
+
+      def test_without_custom_routes
         result = Extractors::RouteExtractor.host_routes
         assert_equal 14, result.count
-        Extractors::RouteExtractor.clear_cache
       end
 
       def test_with_custom_controllers_actions
-        Extractors::RouteExtractor.clear_cache
-        OasRails.config.ignored_actions = []
         init_count = Extractors::RouteExtractor.host_routes.count
         OasRails.config.ignored_actions = ["projects#index"]
         Extractors::RouteExtractor.clear_cache
         result = Extractors::RouteExtractor.host_routes.count
         assert_equal (init_count - 1), result
-        Extractors::RouteExtractor.clear_cache
-        OasRails.config.ignored_actions = []
       end
 
       def test_with_custom_controller_only
-        Extractors::RouteExtractor.clear_cache
         OasRails.config.ignored_actions = ["projects"]
         routes = Extractors::RouteExtractor.host_routes
         result = routes.select { |route| route.controller.include?("projects") }
         assert_equal 0, result.count
-        Extractors::RouteExtractor.clear_cache
-        OasRails.config.ignored_actions = []
+      end
+
+      def test_extract_host_routes_with_tags_mode
+        OasRails.config.include_mode = :with_tags
+        result = Extractors::RouteExtractor.host_routes
+        assert_equal 10, result.count
+      end
+
+      def test_extract_host_routes_explicit_mode
+        OasRails.config.include_mode = :explicit
+        result = Extractors::RouteExtractor.host_routes
+        assert_equal 1, result.count
       end
     end
   end


### PR DESCRIPTION
Add new config: `config.include_mode` with three options: 
- All: for including all routes under the root or api_path configured
- with_tags: for including only endpoints documented with at least one tag
- explicit: you will need to include the endpoints using the tag @oas_include`

Documentation included