### PR TITLE
feat: add config option for engine routes

### DIFF
--- a/lib/oas_rails/configuration.rb
+++ b/lib/oas_rails/configuration.rb
@@ -15,7 +15,7 @@ module OasRails
                   :use_model_names,
                   :rapidoc_theme
 
-    attr_reader :servers, :tags, :security_schema, :include_mode, :response_body_of_default
+    attr_reader :servers, :tags, :security_schema, :include_mode, :response_body_of_default, :routes_provider
 
     def initialize
       @info = Spec::Info.new
@@ -38,6 +38,7 @@ module OasRails
       @use_model_names = false
       @rapidoc_theme = :rails
       @include_mode = :all
+      @routes_provider = Rails.application
 
       @possible_default_responses.each do |response|
         method_name = "response_body_of_#{response}="
@@ -72,6 +73,12 @@ module OasRails
 
     def tags=(value)
       @tags = value.map { |t| Spec::Tag.new(name: t[:name], description: t[:description]) }
+    end
+
+    def routes_provider=(value)
+      raise ArgumentError, "routes_provider must have routes" unless value.respond_to?(:routes)
+
+      @routes_provider = value
     end
 
     def excluded_columns_incoming

--- a/lib/oas_rails/extractors/route_extractor.rb
+++ b/lib/oas_rails/extractors/route_extractor.rb
@@ -56,8 +56,8 @@ module OasRails
         end
 
         def valid_routes
-          Rails.application.routes.routes.select do |route|
-            valid_api_route?(route)
+          OasRails.config.routes_provider.routes.routes.select do |route|
+            route if valid_api_route?(route)
           end
         end
 

--- a/test/lib/oas_rails/configuration_test.rb
+++ b/test/lib/oas_rails/configuration_test.rb
@@ -17,6 +17,7 @@ module OasRails
       assert_equal "Hash{ status: !Integer, error: String }", @config.response_body_of_default
       assert_equal :rails, @config.rapidoc_theme
       assert_equal :all, @config.include_mode
+      assert_equal Rails.application, @config.routes_provider
     end
 
     test "sets and gets servers" do
@@ -72,6 +73,22 @@ module OasRails
         assert_respond_to @config, "response_body_of_#{response}="
         assert_respond_to @config, "response_body_of_#{response}"
       end
+    end
+
+    test "validates routes_provider" do
+      # Test with an object that responds to :routes (should work)
+      mock_routes_provider = Class.new do
+        def routes
+          []
+        end
+      end.new
+
+      @config.routes_provider = mock_routes_provider
+      assert_equal mock_routes_provider, @config.routes_provider
+
+      # Test with an object that doesn't respond to :routes (should raise error)
+      assert_raises(ArgumentError) { @config.routes_provider = "invalid" }
+      assert_raises(ArgumentError) { @config.routes_provider = 123 }
     end
   end
 end


### PR DESCRIPTION
The routes extractor only loops over all routes from the main Rails.application. We have put our API endpoints in a separate engine. These are not included in the main router. Due to differences in how Rails handles routes in different versions I think it's a good idea to add a routes_provider option to the configuration. There you can add a different engine for routes if needed.