### PR TITLE
feat: add configurable route extractor to configuration

### DIFF
--- a/lib/oas_rails/builders/oas_route_builder.rb
+++ b/lib/oas_rails/builders/oas_route_builder.rb
@@ -52,7 +52,7 @@ module OasRails
       end
 
       def path
-        Extractors::RouteExtractor.clean_route(@rails_route.path.spec.to_s)
+        OasRails.config.route_extractor.clean_route(@rails_route.path.spec.to_s)
       end
 
       def source_string

--- a/lib/oas_rails/builders/path_item_builder.rb
+++ b/lib/oas_rails/builders/path_item_builder.rb
@@ -6,8 +6,8 @@ module OasRails
         @path_item = Spec::PathItem.new(specification)
       end
 
-      def from_path(path, route_extractor: Extractors::RouteExtractor)
-        route_extractor.host_routes_by_path(path).each do |oas_route|
+      def from_path(path)
+        OasRails.config.route_extractor.host_routes_by_path(path).each do |oas_route|
           oas_route.verb.downcase.split("|").each do |v|
             @path_item.add_operation(v, OperationBuilder.new(@specification).from_oas_route(oas_route).build)
           end

--- a/lib/oas_rails/configuration.rb
+++ b/lib/oas_rails/configuration.rb
@@ -15,7 +15,7 @@ module OasRails
                   :use_model_names,
                   :rapidoc_theme
 
-    attr_reader :servers, :tags, :security_schema, :include_mode, :response_body_of_default
+    attr_reader :servers, :tags, :security_schema, :include_mode, :response_body_of_default, :route_extractor
 
     def initialize
       @info = Spec::Info.new
@@ -38,6 +38,7 @@ module OasRails
       @use_model_names = false
       @rapidoc_theme = :rails
       @include_mode = :all
+      @route_extractor = Extractors::RouteExtractor
 
       @possible_default_responses.each do |response|
         method_name = "response_body_of_#{response}="
@@ -72,6 +73,19 @@ module OasRails
 
     def tags=(value)
       @tags = value.map { |t| Spec::Tag.new(name: t[:name], description: t[:description]) }
+    end
+
+    def route_extractor=(value)
+      unless value.respond_to?(:host_routes) &&
+             value.respond_to?(:host_routes_by_path) &&
+             value.respond_to?(:clear_cache) &&
+             value.respond_to?(:host_paths) &&
+             value.respond_to?(:clean_route)
+        raise ArgumentError,
+              "Route extractor must have the following methods: host_routes, host_routes_by_path, clear_cache, host_paths, and clean_route"
+      end
+
+      @route_extractor = value
     end
 
     def excluded_columns_incoming

--- a/lib/oas_rails/spec/path_item.rb
+++ b/lib/oas_rails/spec/path_item.rb
@@ -13,8 +13,8 @@ module OasRails
         @delete = nil
       end
 
-      def fill_from(path, route_extractor: Extractors::RouteExtractor)
-        route_extractor.host_routes_by_path(path).each do |oas_route|
+      def fill_from(path)
+        OasRails.config.route_extractor.host_routes_by_path(path).each do |oas_route|
           add_operation(oas_route.verb.downcase, Spec::Operation.new(@specification).fill_from(oas_route))
         end
 

--- a/lib/oas_rails/spec/specification.rb
+++ b/lib/oas_rails/spec/specification.rb
@@ -20,8 +20,8 @@ module OasRails
         @paths = Spec::Paths.new(self)
       end
 
-      def build(route_extractor: Extractors::RouteExtractor)
-        route_extractor.host_paths.each do |path|
+      def build
+        OasRails.config.route_extractor.host_paths.each do |path|
           @paths.add_path(path)
         end
       end
@@ -31,7 +31,7 @@ module OasRails
       # @return [void]
       def clear_cache
         MethodSource.clear_cache
-        Extractors::RouteExtractor.clear_cache
+        OasRails.config.route_extractor.clear_cache
       end
 
       def oas_fields

--- a/test/lib/oas_rails/configuration_test.rb
+++ b/test/lib/oas_rails/configuration_test.rb
@@ -73,5 +73,21 @@ module OasRails
         assert_respond_to @config, "response_body_of_#{response}"
       end
     end
+
+    MockRouteExtractor = Struct.new(:host_routes, :host_routes_by_path, :clear_cache, :host_paths, :clean_route)
+
+    test "validates route_extractor" do
+      # Test with an object that responds to :routes (should work)
+      mock_route_extractor = MockRouteExtractor.new([], [], proc {}, [], proc {})
+
+      @config.route_extractor = mock_route_extractor
+
+      assert_equal mock_route_extractor, @config.route_extractor
+
+      # Test with an object that doesn't respond to :routes (should raise error)
+      assert_raises(ArgumentError) { @config.route_extractor = "invalid" }
+      assert_raises(ArgumentError) { @config.route_extractor = 123 }
+      assert_raises(ArgumentError) { @config.route_extractor = Class.new }
+    end
   end
 end


### PR DESCRIPTION
Variation on https://github.com/a-chacon/oas_rails/pull/133 where you can configure the `route_extractor` and provide your own one so you can use one or multiple other engines to add routes.