### PR TITLE
feat: add route overrides

### DIFF
--- a/lib/generators/oas_rails/config/templates/oas_rails_initializer.rb
+++ b/lib/generators/oas_rails/config/templates/oas_rails_initializer.rb
@@ -110,4 +110,18 @@ OasRails.configure do |config|
   # config.possible_default_responses = [:not_found, :unauthorized, :forbidden, :internal_server_error, :unprocessable_entity]
   # config.response_body_of_default = "Hash{ message: String }"
   # config.response_body_of_unprocessable_entity= "Hash{ errors: Array<String> }"
+
+  # ###########################
+  # Route Overrides
+  # ###########################
+  # Overrides the default route information (for example, to add or change information on nested routes since they use the same action, and thus cannot be documented separately).
+  # Example:
+  # config.route_overrides = {
+  #   "/users/{user_id}/projects" => {
+  #     summary: "List projects for a user",
+  #     parameters: [
+  #       { name: "user_id", in: "path", type: "integer", required: true, description: "ID of the user" }
+  #     ]
+  #   }
+  # }
 end

--- a/lib/oas_rails/builders/parameters_builder.rb
+++ b/lib/oas_rails/builders/parameters_builder.rb
@@ -7,9 +7,22 @@ module OasRails
       end
 
       def from_oas_route(oas_route)
-        parameters_from_tags(tags: oas_route.tags(:parameter))
-        oas_route.path_params.try(:map) do |p|
-          @parameters << ParameterBuilder.new(@specification).from_path(oas_route.path, p).build unless @parameters.any? { |param| param.name.to_s == p.to_s }
+        override = OasRails.config.route_overrides[oas_route.path]
+        if override && override[:parameters]
+          override[:parameters].each do |param|
+            parameter = Spec::Parameter.new(@specification)
+            parameter.name = param[:name]
+            parameter.in = param[:in]
+            parameter.required = param.key?(:required) ? param[:required] : (param[:in] == "path")
+            parameter.schema = { type: param[:type] || "string" }
+            parameter.description = param[:description] || ""
+            @parameters << parameter
+          end
+        else
+          parameters_from_tags(tags: oas_route.tags(:parameter))
+          oas_route.path_params.try(:map) do |p|
+            @parameters << ParameterBuilder.new(@specification).from_path(oas_route.path, p).build unless @parameters.any? { |param| param.name.to_s == p.to_s }
+          end
         end
 
         self

--- a/lib/oas_rails/configuration.rb
+++ b/lib/oas_rails/configuration.rb
@@ -13,7 +13,8 @@ module OasRails
                   :possible_default_responses,
                   :http_verbs,
                   :use_model_names,
-                  :rapidoc_theme
+                  :rapidoc_theme,
+                  :route_overrides
 
     attr_reader :servers, :tags, :security_schema, :include_mode, :response_body_of_default, :route_extractor
 
@@ -39,6 +40,7 @@ module OasRails
       @rapidoc_theme = :rails
       @include_mode = :all
       @route_extractor = Extractors::RouteExtractor
+      @route_overrides = {}
 
       @possible_default_responses.each do |response|
         method_name = "response_body_of_#{response}="

--- a/lib/oas_rails/extractors/oas_route_extractor.rb
+++ b/lib/oas_rails/extractors/oas_route_extractor.rb
@@ -2,6 +2,8 @@ module OasRails
   module Extractors
     module OasRouteExtractor
       def extract_summary(oas_route:)
+        override = OasRails.config.route_overrides[oas_route.path]
+        return override[:summary] if override && override[:summary]
         oas_route.tags(:summary).first.try(:text) || generate_crud_name(oas_route.method, oas_route.controller.downcase) || "#{oas_route.verb} #{oas_route.path}"
       end
 


### PR DESCRIPTION
Hey, thanks for your work on oas_rails, it really is a great project!

I've been using it in a project which uses a Rails API server, but ran into some issues where some routes use nested resources.
This meant that multiple routes call the same action, causing them to have the same name and parameters even though they are technically different routes, just processed by the same action. I needed a way to be able to override the route info for these nested routes so I can display a different name and parameters for them.

I opted to do that through the initializer config rather than changing how the tags themselves work since I'm not sure of any way to do that within the YARD spec.

I added this feature for my own needs, but figured it may be useful for others, hence the PR. Of course, feel free to close this if it's not up to spec for the project, this was just a quick modification to make this project work for me. Happy to make changes if needed.