### PR TITLE
Fix custom route extractor usage

### DIFF
--- a/lib/oas_rails.rb
+++ b/lib/oas_rails.rb
@@ -33,7 +33,7 @@ module OasRails
       clear_cache
       OasCore.config = config
 
-      host_routes = Extractors::RouteExtractor.host_routes
+      host_routes = config.route_extractor.host_routes
       oas_source = config.source_oas_path ? read_source_oas_file : {}
 
       OasCore.build(host_routes, oas_source: oas_source)

--- a/test/oas_rails_test.rb
+++ b/test/oas_rails_test.rb
@@ -4,4 +4,27 @@ class OasRailsTest < ActiveSupport::TestCase
   test "it has a version number" do
     assert OasRails::VERSION
   end
+
+  class MockRouteExtractor < OasRails::Extractors::RouteExtractor
+    def self.host_routes
+      super.select { |route| route.controller.include?("users") }
+    end
+  end
+
+  test "it builds with the configured route extractor" do
+    config = OasRails::Configuration.new
+    config.route_extractor = MockRouteExtractor
+
+    OasRails.stub(:config, config) do
+      custom_routes = OasRails.config.route_extractor.host_routes
+      assert custom_routes.all? { |route| route.controller.include?("users") }, "Expected to get user routes only"
+
+      oas_core_mock = Minitest::Mock.new
+      oas_core_mock.expect(:build, nil, [custom_routes, { oas_source: {} }])
+      OasCore.stub(:build, ->(*args) { oas_core_mock.build(*args) }) do
+        OasRails.build
+      end
+      oas_core_mock.verify
+    end
+  end
 end


### PR DESCRIPTION
This PR fixes a bug that was introduced in [this commit](https://github.com/a-chacon/oas_rails/commit/5c3801110f77d38891bf644ec0ca9e0191195d83#diff-414c3479aa44def2565e8711c56865a78202025490a282f1611b061e9df6bf00) where custom routes stopped loading after upgrading to `1.0.0`.
