### PR TITLE
Support providing some rapi-doc config 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,6 +163,8 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.4)
+    nokogiri (1.18.9-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.18.9-x86_64-linux-gnu)
       racc (~> 1.4)
     oas_core (1.1.0)
@@ -267,6 +269,7 @@ GEM
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
+    sqlite3 (2.7.3-arm64-darwin)
     sqlite3 (2.7.3-x86_64-linux-gnu)
     stringio (3.1.7)
     thor (1.4.0)
@@ -295,6 +298,7 @@ GEM
     zeitwerk (2.7.3)
 
 PLATFORMS
+  arm64-darwin-24
   x86_64-linux
 
 DEPENDENCIES

--- a/app/controllers/oas_rails/oas_rails_controller.rb
+++ b/app/controllers/oas_rails/oas_rails_controller.rb
@@ -2,7 +2,6 @@ module OasRails
   class OasRailsController < ApplicationController
     # Include URL help if the layout is a user-customized layout.
     include Rails.application.routes.url_helpers
-    include OasRailsHelper
     
     def index
       respond_to do |format|

--- a/app/controllers/oas_rails/oas_rails_controller.rb
+++ b/app/controllers/oas_rails/oas_rails_controller.rb
@@ -2,7 +2,8 @@ module OasRails
   class OasRailsController < ApplicationController
     # Include URL help if the layout is a user-customized layout.
     include Rails.application.routes.url_helpers
-
+    include OasRailsHelper
+    
     def index
       respond_to do |format|
         format.html { render "index", layout: OasRails.config.layout }

--- a/app/controllers/oas_rails/oas_rails_controller.rb
+++ b/app/controllers/oas_rails/oas_rails_controller.rb
@@ -2,6 +2,7 @@ module OasRails
   class OasRailsController < ApplicationController
     # Include URL help if the layout is a user-customized layout.
     include Rails.application.routes.url_helpers
+
     def index
       respond_to do |format|
         format.html { render "index", layout: OasRails.config.layout }

--- a/app/controllers/oas_rails/oas_rails_controller.rb
+++ b/app/controllers/oas_rails/oas_rails_controller.rb
@@ -2,7 +2,6 @@ module OasRails
   class OasRailsController < ApplicationController
     # Include URL help if the layout is a user-customized layout.
     include Rails.application.routes.url_helpers
-    
     def index
       respond_to do |format|
         format.html { render "index", layout: OasRails.config.layout }

--- a/app/helpers/oas_rails/oas_rails_helper.rb
+++ b/app/helpers/oas_rails/oas_rails_helper.rb
@@ -2,7 +2,7 @@ module OasRails
   module OasRailsHelper
     def rapi_doc_config
       {
-        "spec-url" => "#{OasRails::Engine.routes.find_script_name({})}.json"
+        "spec-url" => "#{OasRails::Engine.routes.find_script_name({})}.json",
         "show-header" => "true",
         "font-size" => "largest",
         "show-method-in-nav-bar" => "as-colored-text",

--- a/app/helpers/oas_rails/oas_rails_helper.rb
+++ b/app/helpers/oas_rails/oas_rails_helper.rb
@@ -11,10 +11,11 @@ module OasRails
         "schema-style" => "table",
         "sort-tags" => "true",
         "persist-auth" => "true"
-      }.map { |k, v| %(#{k}=#{ERB::Util.html_escape(v)}) }.join(' ')
+      }.merge(OasRails.config.rapi_docs_configuration).map { |k, v| %(#{k}=#{ERB::Util.html_escape(v)}) }.join(' ')
     end
 
-    def logo_url
+    def rapi_docs_logo_url
+      OasRails.config.rapi_docs_logo_url
       false
     end
   end

--- a/app/helpers/oas_rails/oas_rails_helper.rb
+++ b/app/helpers/oas_rails/oas_rails_helper.rb
@@ -11,7 +11,7 @@ module OasRails
         "schema-style" => "table",
         "sort-tags" => "true",
         "persist-auth" => "true"
-      }.map { |k, v| %(#{k}="#{ERB::Util.html_escape(v)}") }.join(' ')
+      }.map { |k, v| %(#{k}=#{ERB::Util.html_escape(v)}) }.join(' ')
     end
 
     def logo_url

--- a/app/helpers/oas_rails/oas_rails_helper.rb
+++ b/app/helpers/oas_rails/oas_rails_helper.rb
@@ -3,7 +3,7 @@ module OasRails
     def rapidoc_configuration_attributes
       {
         "spec-url" => "#{OasRails::Engine.routes.find_script_name({})}.json",
-        "show-header" => "true",
+        "show-header" => "false",
         "font-size" => "largest",
         "show-method-in-nav-bar" => "as-colored-text",
         "nav-item-spacing" => "relaxed",

--- a/app/helpers/oas_rails/oas_rails_helper.rb
+++ b/app/helpers/oas_rails/oas_rails_helper.rb
@@ -1,6 +1,6 @@
 module OasRails
   module OasRailsHelper
-    def rapi_docs_configuration_attributes
+    def rapidoc_configuration_attributes
       {
         "spec-url" => "#{OasRails::Engine.routes.find_script_name({})}.json",
         "show-header" => "true",
@@ -11,11 +11,11 @@ module OasRails
         "schema-style" => "table",
         "sort-tags" => "true",
         "persist-auth" => "true"
-      }.merge(OasRails.config.rapi_docs_configuration).map { |k, v| %(#{k}=#{ERB::Util.html_escape(v)}) }.join(' ')
+      }.merge(OasRails.config.rapidoc_configuration).map { |k, v| %(#{k}=#{ERB::Util.html_escape(v)}) }.join(' ')
     end
 
-    def rapi_docs_logo_url
-      OasRails.config.rapi_docs_logo_url
+    def rapidoc_logo_url
+      OasRails.config.rapidoc_logo_url
     end
   end
 end

--- a/app/helpers/oas_rails/oas_rails_helper.rb
+++ b/app/helpers/oas_rails/oas_rails_helper.rb
@@ -11,7 +11,7 @@ module OasRails
         "schema-style" => "table",
         "sort-tags" => "true",
         "persist-auth" => "true"
-      }
+      }.map { |k, v| %(#{k}="#{ERB::Util.html_escape(v)}") }.join(' ')
     end
 
     def logo_url

--- a/app/helpers/oas_rails/oas_rails_helper.rb
+++ b/app/helpers/oas_rails/oas_rails_helper.rb
@@ -16,7 +16,6 @@ module OasRails
 
     def rapi_docs_logo_url
       OasRails.config.rapi_docs_logo_url
-      false
     end
   end
 end

--- a/app/helpers/oas_rails/oas_rails_helper.rb
+++ b/app/helpers/oas_rails/oas_rails_helper.rb
@@ -1,4 +1,21 @@
 module OasRails
   module OasRailsHelper
+    def rapi_doc_config
+      {
+        "spec-url" => "#{OasRails::Engine.routes.find_script_name({})}.json"
+        "show-header" => "true",
+        "font-size" => "largest",
+        "show-method-in-nav-bar" => "as-colored-text",
+        "nav-item-spacing" => "relaxed",
+        "allow-spec-file-download" => "true",
+        "schema-style" => "table",
+        "sort-tags" => "true",
+        "persist-auth" => "true"
+      }
+    end
+
+    def logo_url
+      false
+    end
   end
 end

--- a/app/helpers/oas_rails/oas_rails_helper.rb
+++ b/app/helpers/oas_rails/oas_rails_helper.rb
@@ -1,6 +1,6 @@
 module OasRails
   module OasRailsHelper
-    def rapi_docs_config
+    def rapi_docs_configuration_attributes
       {
         "spec-url" => "#{OasRails::Engine.routes.find_script_name({})}.json",
         "show-header" => "true",

--- a/app/helpers/oas_rails/oas_rails_helper.rb
+++ b/app/helpers/oas_rails/oas_rails_helper.rb
@@ -1,6 +1,6 @@
 module OasRails
   module OasRailsHelper
-    def rapi_doc_config
+    def rapi_docs_config
       {
         "spec-url" => "#{OasRails::Engine.routes.find_script_name({})}.json",
         "show-header" => "true",

--- a/app/views/oas_rails/oas_rails/index.html.erb
+++ b/app/views/oas_rails/oas_rails/index.html.erb
@@ -126,7 +126,7 @@
   </head>
   <body>
     <rapi-doc <%= rapidoc_configuration_attributes %> >
-      <% if logo_url %>
+      <% if rapidoc_logo_url %>
         <img
           slot="nav-logo"
           src="<%= rapidoc_logo_url %>"

--- a/app/views/oas_rails/oas_rails/index.html.erb
+++ b/app/views/oas_rails/oas_rails/index.html.erb
@@ -131,7 +131,7 @@
           slot="nav-logo"
           src="<%= logo_url %>"
         />
-      <% end_if %>
+      <% end %>
     </rapi-doc>
 
     <style>

--- a/app/views/oas_rails/oas_rails/index.html.erb
+++ b/app/views/oas_rails/oas_rails/index.html.erb
@@ -125,7 +125,7 @@
     </script>
   </head>
   <body>
-    <rapi-doc <%= **rapi_docs_config %> >
+    <rapi-doc <%= rapi_docs_config %> >
       <% if logo_url %>
         <img
           slot="nav-logo"

--- a/app/views/oas_rails/oas_rails/index.html.erb
+++ b/app/views/oas_rails/oas_rails/index.html.erb
@@ -125,7 +125,7 @@
     </script>
   </head>
   <body>
-    <rapi-doc <%= rapi_docs_config %> >
+    <rapi-doc <%= rapi_docs_logo_url %> >
       <% if logo_url %>
         <img
           slot="nav-logo"

--- a/app/views/oas_rails/oas_rails/index.html.erb
+++ b/app/views/oas_rails/oas_rails/index.html.erb
@@ -125,17 +125,13 @@
     </script>
   </head>
   <body>
-    <rapi-doc
-      spec-url="<%= OasRails::Engine.routes.find_script_name({}) %>.json"
-      show-header="false"
-      font-size="largest"
-      show-method-in-nav-bar="as-colored-text"
-      nav-item-spacing="relaxed"
-      allow-spec-file-download="true"
-      schema-style="table"
-      sort-tags="true"
-      persist-auth="true"
-    >
+    <rapi-doc <%= **rapi_docs_config %> >
+      <% if logo_url %>
+        <img
+          slot="nav-logo"
+          src="<%= logo_url %>"
+        />
+      <% end_if %>
     </rapi-doc>
 
     <style>

--- a/app/views/oas_rails/oas_rails/index.html.erb
+++ b/app/views/oas_rails/oas_rails/index.html.erb
@@ -125,11 +125,11 @@
     </script>
   </head>
   <body>
-    <rapi-doc <%= rapi_docs_configuration_attributes %> >
+    <rapi-doc <%= rapidoc_configuration_attributes %> >
       <% if logo_url %>
         <img
           slot="nav-logo"
-          src="<%= rapi_docs_logo_url %>"
+          src="<%= rapidoc_logo_url %>"
         />
       <% end %>
     </rapi-doc>

--- a/app/views/oas_rails/oas_rails/index.html.erb
+++ b/app/views/oas_rails/oas_rails/index.html.erb
@@ -125,11 +125,11 @@
     </script>
   </head>
   <body>
-    <rapi-doc <%= rapi_docs_logo_url %> >
+    <rapi-doc <%= rapi_docs_configuration_attributes %> >
       <% if logo_url %>
         <img
           slot="nav-logo"
-          src="<%= logo_url %>"
+          src="<%= rapi_docs_logo_url %>"
         />
       <% end %>
     </rapi-doc>

--- a/lib/generators/oas_rails/config/templates/oas_rails_initializer.rb
+++ b/lib/generators/oas_rails/config/templates/oas_rails_initializer.rb
@@ -70,6 +70,14 @@ OasRails.configure do |config|
   # Default: false
   # config.layout = "application"
 
+  # Override general rapi-doc settings
+  # config.rapidoc_configuration
+  # default: {}
+
+  # Add a logo to rapi-doc
+  # config.rapidoc_logo_url
+  # default: nil
+
   # Excluding custom controllers or controllers#action
   # Example: ["projects", "users#new"]
   # config.ignored_actions = []

--- a/lib/oas_rails/configuration.rb
+++ b/lib/oas_rails/configuration.rb
@@ -1,6 +1,6 @@
 module OasRails
   class Configuration < OasCore::Configuration
-    attr_accessor :autodiscover_request_body, :autodiscover_responses, :ignored_actions, :rapidoc_theme, :layout, :source_oas_path
+    attr_accessor :autodiscover_request_body, :autodiscover_responses, :ignored_actions, :rapidoc_theme, :layout, :source_oas_path, :rapi_docs_configuration, :rapi_docs_logo_url
     attr_reader :route_extractor, :include_mode
 
     def initialize
@@ -12,6 +12,8 @@ module OasRails
       @ignored_actions = []
       @rapidoc_theme = :rails
       @layout = nil
+      @rapi_docs_configuration = {}
+      @rapi_docs_logo_url = nil
       @source_oas_path = nil
 
       # TODO: implement

--- a/lib/oas_rails/configuration.rb
+++ b/lib/oas_rails/configuration.rb
@@ -1,6 +1,6 @@
 module OasRails
   class Configuration < OasCore::Configuration
-    attr_accessor :autodiscover_request_body, :autodiscover_responses, :ignored_actions, :rapidoc_theme, :layout, :source_oas_path, :rapi_docs_configuration, :rapi_docs_logo_url
+    attr_accessor :autodiscover_request_body, :autodiscover_responses, :ignored_actions, :rapidoc_theme, :layout, :source_oas_path, :rapidoc_configuration, :rapidoc_logo_url
     attr_reader :route_extractor, :include_mode
 
     def initialize

--- a/lib/oas_rails/configuration.rb
+++ b/lib/oas_rails/configuration.rb
@@ -12,8 +12,8 @@ module OasRails
       @ignored_actions = []
       @rapidoc_theme = :rails
       @layout = nil
-      @rapi_docs_configuration = {}
-      @rapi_docs_logo_url = nil
+      @rapidoc_configuration = {}
+      @rapidoc_logo_url = nil
       @source_oas_path = nil
 
       # TODO: implement


### PR DESCRIPTION
given the changes to get persistant auth, figured adding the ability to override any options the rapi-doc setting might be the way forward.

Just adds the ability to override initializer settings for rapi-doc
Also supports the logo logic

i know this can be done via a custom template, but figured for the minor adjustments that many would need this should do the job.

The only thing missing is the update to Core to support the new config options ( i think).

But it is working as is

If your happy for this sort of change, ill also update the helper to manage the theme with the ability to override specific parts allowing for say "purple" theme + merge of "Extra style attributes"