### PR TITLE
feat: inject config as dependency so we can have multiple docs instances

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,9 +1,14 @@
 inherit_from: .rubocop_todo.yml
 AllCops:
-  TargetRubyVersion:
   NewCops: enable
   SuggestExtensions: false
   Exclude:
     - "gemfiles/*"
     - "vendor/**/*"
     - "test/dummy/db/schema.rb"
+
+Metrics/ParameterLists:
+  Enabled: false
+
+Metrics/ClassLength:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,3 +12,9 @@ Metrics/ParameterLists:
 
 Metrics/ClassLength:
   Enabled: false
+
+Metrics/BlockLength:
+  Enabled: false
+
+Style/ClassAndModuleChildren:
+  Enabled: false

--- a/app/controllers/oas_rails/oas_rails_controller.rb
+++ b/app/controllers/oas_rails/oas_rails_controller.rb
@@ -3,13 +3,22 @@ module OasRails
     # Include URL help if the layout is a user-customized layout.
     include Rails.application.routes.url_helpers
 
+    before_action :resolve_config
+
     def index
       respond_to do |format|
-        format.html { render "index", layout: OasRails.config.layout }
+        format.html { render "index", layout: @config.layout }
         format.json do
-          render json: OasRails.build.to_json, status: :ok
+          render json: OasRails.build(config: @config).to_json, status: :ok
         end
       end
+    end
+
+    private
+
+    def resolve_config
+      config_name = params.dig("default", "configuration")&.to_sym || :default
+      @config = OasRails.config(config_name)
     end
   end
 end

--- a/app/helpers/oas_rails/oas_rails_helper.rb
+++ b/app/helpers/oas_rails/oas_rails_helper.rb
@@ -2,7 +2,7 @@ module OasRails
   module OasRailsHelper # rubocop:disable Metrics/ModuleLength
     def rapidoc_configuration_defaults
       {
-        "spec-url" => "#{OasRails::Engine.routes.find_script_name(params.permit!.to_h.symbolize_keys)}.json",
+        "spec-url" => "#{request.script_name}.json",
         "show-header" => "false",
         "font-size" => "largest",
         "show-method-in-nav-bar" => "as-colored-text",
@@ -16,13 +16,13 @@ module OasRails
 
     def rapidoc_configuration_attributes
       rapidoc_configuration_defaults.merge(
-        rapidoc_theme(OasRails.config.rapidoc_theme),
-        OasRails.config.rapidoc_configuration
+        rapidoc_theme(@config.rapidoc_theme),
+        @config.rapidoc_configuration
       ).map { |k, v| %(#{k}=#{ERB::Util.html_escape(v)}) }.join(' ')
     end
 
     def rapidoc_logo_url
-      OasRails.config.rapidoc_logo_url
+      @config.rapidoc_logo_url
     end
 
     THEMES = {

--- a/lib/oas_rails.rb
+++ b/lib/oas_rails.rb
@@ -24,39 +24,48 @@ module OasRails
   end
 
   class << self
+    # NOTE: This lambda is called back by OasCore during build and has no way to receive
+    # a named config as a parameter. It falls back to OasRails.config(:default).
+    # This is a known limitation: excluded_columns in EsquemaBuilder will always use
+    # the default config when invoked from this re-entry point.
     OasCore::JsonSchemaGenerator.register_type_parser(
       ->(t) { Utils.active_record_class?(t) },
       ->(type, _required) { Builders::EsquemaBuilder.build_outgoing_schema(klass: type.constantize) }
     )
 
-    def build
-      clear_cache
+    def build(config: OasRails.config)
+      clear_cache(config:)
       OasCore.config = config
 
-      host_routes = config.route_extractor.host_routes
-      oas_source = config.source_oas_path ? read_source_oas_file : {}
+      host_routes = config.route_extractor.host_routes(config:)
+      oas_source = config.source_oas_path ? read_source_oas_file(config:) : {}
 
       OasCore.build(host_routes, oas_source: oas_source)
     end
 
-    def configure
-      yield config
+    def configure(name = :default)
+      cfg = Configuration.new
+      yield cfg
+      cfg.instance_variable_set(:@name, name)
+      @configs ||= {}
+      @configs[name] = cfg
     end
 
-    def config
-      @config ||= Configuration.new
+    def config(name = :default)
+      @configs ||= {}
+      @configs[name] ||= Configuration.new
     end
 
     private
 
-    def clear_cache
+    def clear_cache(config:)
       return if Rails.env.production?
 
       MethodSource.clear_cache
-      OasRails::Extractors::RouteExtractor.clear_cache
+      OasRails::Extractors::RouteExtractor.clear_cache(config:)
     end
 
-    def read_source_oas_file
+    def read_source_oas_file(config:)
       file_path = Rails.root.join(config.source_oas_path)
       JSON.parse(File.read(file_path), symbolize_names: true)
     rescue Errno::ENOENT => e

--- a/lib/oas_rails/active_record_example_finder.rb
+++ b/lib/oas_rails/active_record_example_finder.rb
@@ -1,12 +1,13 @@
 module OasRails
   class ActiveRecordExampleFinder
-    def initialize(context: :incoming, utils: Utils, factory_bot: FactoryBot, erb: ERB, yaml: YAML, file: File)
+    def initialize(context: :incoming, utils: Utils, factory_bot: FactoryBot, erb: ERB, yaml: YAML, file: File, config: nil)
       @context = context
       @utils = utils
       @factory_bot = factory_bot
       @erb = erb
       @yaml = yaml
       @file = file
+      @config = config
       @factory_examples = {}
     end
 
@@ -59,7 +60,8 @@ module OasRails
     end
 
     def clean_example_object(obj:)
-      obj.reject { |key, _| OasRails.config.send("excluded_columns_#{@context}").include?(key.to_sym) }
+      resolved_config = @config || OasRails.config
+      obj.reject { |key, _| resolved_config.send("excluded_columns_#{@context}").include?(key.to_sym) }
     end
   end
 end

--- a/lib/oas_rails/builders/esquema_builder.rb
+++ b/lib/oas_rails/builders/esquema_builder.rb
@@ -5,12 +5,14 @@ module OasRails
         # Builds a schema for a class when it is used as incoming API data.
         #
         # @param klass [Class] The class for which the schema is built.
+        # @param config [OasRails::Configuration, nil] Optional config override; falls back to OasRails.config.
         # @return [Hash] The schema as a JSON-compatible hash.
-        def build_incoming_schema(klass:, model_to_schema_class: EasyTalk)
+        def build_incoming_schema(klass:, model_to_schema_class: EasyTalk, config: nil)
+          resolved_config = config || OasRails.config
           build_schema(
             klass: klass,
             model_to_schema_class: model_to_schema_class,
-            excluded_columns: OasRails.config.excluded_columns_incoming,
+            excluded_columns: resolved_config.excluded_columns_incoming,
             exclude_primary_key: true
           )
         end
@@ -18,12 +20,14 @@ module OasRails
         # Builds a schema for a class when it is used as outgoing API data.
         #
         # @param klass [Class] The class for which the schema is built.
+        # @param config [OasRails::Configuration, nil] Optional config override; falls back to OasRails.config.
         # @return [Hash] The schema as a JSON-compatible hash.
-        def build_outgoing_schema(klass:, model_to_schema_class: EasyTalk)
+        def build_outgoing_schema(klass:, model_to_schema_class: EasyTalk, config: nil)
+          resolved_config = config || OasRails.config
           build_schema(
             klass: klass,
             model_to_schema_class: model_to_schema_class,
-            excluded_columns: OasRails.config.excluded_columns_outgoing,
+            excluded_columns: resolved_config.excluded_columns_outgoing,
             exclude_primary_key: false
           )
         end

--- a/lib/oas_rails/builders/oas_route_builder.rb
+++ b/lib/oas_rails/builders/oas_route_builder.rb
@@ -7,12 +7,13 @@ module OasRails
       # source file directly so that OasRails annotations remain readable.
       KNOWN_RUNTIME_WRAPPERS = %w[sorbet-runtime].freeze
 
-      def self.build_from_rails_route(rails_route)
-        new(rails_route).build
+      def self.build_from_rails_route(rails_route, config:)
+        new(rails_route, config:).build
       end
 
-      def initialize(rails_route)
+      def initialize(rails_route, config:)
         @rails_route = rails_route
+        @config = config
       end
 
       def build
@@ -46,7 +47,7 @@ module OasRails
       end
 
       def path
-        OasRails.config.prefix_path + OasRails.config.route_extractor.clean_route(@rails_route.path.spec.to_s)
+        @config.prefix_path + @config.route_extractor.clean_route(@rails_route.path.spec.to_s)
       end
 
       def source_string

--- a/lib/oas_rails/configuration.rb
+++ b/lib/oas_rails/configuration.rb
@@ -1,10 +1,11 @@
 module OasRails
   class Configuration < OasCore::Configuration
     attr_accessor :autodiscover_request_body, :autodiscover_responses, :ignored_actions, :rapidoc_theme, :layout, :source_oas_path, :rapidoc_configuration, :rapidoc_logo_url
-    attr_reader :route_extractor, :include_mode, :mounted_path, :prefix_path
+    attr_reader :name, :route_extractor, :include_mode, :mounted_path, :prefix_path
 
     def initialize
       super
+      @name = :default
       @mounted_path = ""
       self.prefix_path = ENV["RAILS_RELATIVE_URL_ROOT"] || Rails.application.config.relative_url_root || ""
       @route_extractor = Extractors::RouteExtractor

--- a/lib/oas_rails/extractors/render_response_extractor.rb
+++ b/lib/oas_rails/extractors/render_response_extractor.rb
@@ -2,6 +2,12 @@ module OasRails
   module Extractors
     # Extracts and processes render responses from a given source.
     module RenderResponseExtractor
+      # NOTE: This module is invoked as a callback by OasCore during the build pipeline.
+      # Because OasCore controls the call site, it is not possible to inject a named config
+      # here via dependency injection. As a result, calls to EsquemaBuilder and
+      # ActiveRecordExampleFinder from this module will use OasRails.config(:default).
+      # This is a known limitation of the multi-config feature.
+
       class << self
         # Extracts responses from the provided source string.
         #

--- a/lib/oas_rails/extractors/route_extractor.rb
+++ b/lib/oas_rails/extractors/route_extractor.rb
@@ -10,25 +10,36 @@ module OasRails
       ].freeze
 
       class << self
-        def host_routes_by_path(path)
-          @host_routes ||= extract_host_routes
-          @host_routes.select { |r| r.path == path }
+        def host_routes_by_path(path, config:)
+          @host_routes_cache ||= {}
+          @host_routes_cache[config.name] ||= extract_host_routes(config:)
+          @host_routes_cache[config.name].select { |r| r.path == path }
         end
 
-        def host_routes
-          @host_routes ||= extract_host_routes
+        def host_routes(config:)
+          @host_routes_cache ||= {}
+          @host_routes_cache[config.name] ||= extract_host_routes(config:)
         end
 
-        # Clear Class Instance Variable @host_routes
+        # Clear the cached routes.
         #
-        # This method clear the class instance variable @host_routes
-        # to force a extraction of the routes again.
-        def clear_cache
-          @host_routes = nil
+        # When a +config+ is given, only that config's cache entry is cleared,
+        # forcing the next call to re-extract routes for that configuration.
+        # When called without arguments, the entire cache is cleared for all
+        # configurations.
+        def clear_cache(config: nil)
+          if config
+            @host_routes_cache&.delete(config.name)
+            @host_paths_cache&.delete(config.name)
+          else
+            @host_routes_cache = nil
+            @host_paths_cache = nil
+          end
         end
 
-        def host_paths
-          @host_paths ||= host_routes.map(&:path).uniq.sort
+        def host_paths(config:)
+          @host_paths_cache ||= {}
+          @host_paths_cache[config.name] ||= host_routes(config:).map(&:path).uniq.sort
         end
 
         def clean_route(route)
@@ -37,25 +48,25 @@ module OasRails
 
         private
 
-        def extract_host_routes
-          routes = valid_routes.map { |r| Builders::OasRouteBuilder.build_from_rails_route(r) }
+        def extract_host_routes(config:)
+          routes = valid_routes(config:).map { |r| Builders::OasRouteBuilder.build_from_rails_route(r, config:) }
 
-          routes.select! { |route| route.tags.any? } if OasRails.config.include_mode == :with_tags
-          routes.select! { |route| route.tags.any? { |t| t.tag_name == "oas_include" } } if OasRails.config.include_mode == :explicit
+          routes.select! { |route| route.tags.any? } if config.include_mode == :with_tags
+          routes.select! { |route| route.tags.any? { |t| t.tag_name == "oas_include" } } if config.include_mode == :explicit
           routes
         end
 
-        def valid_routes
+        def valid_routes(config:)
           Rails.application.routes.routes.select do |route|
-            valid_api_route?(route)
+            valid_api_route?(route, config:)
           end
         end
 
-        def valid_api_route?(route)
+        def valid_api_route?(route, config:)
           return false unless valid_route_implementation?(route)
           return false if RAILS_DEFAULT_CONTROLLERS.any? { |default| route.defaults[:controller].start_with?(default) }
-          return false unless route.path.spec.to_s.start_with?(OasRails.config.api_path)
-          return false if ignore_custom_actions?(route)
+          return false unless route.path.spec.to_s.start_with?(config.api_path)
+          return false if ignore_custom_actions?(route, config:)
 
           true
         end
@@ -88,9 +99,9 @@ module OasRails
         # Support controller name only to ignore all controller actions.
         # Support ignoring "controller#action"
         # Ignoring "controller#action" AND "api_path/controller#action"
-        def ignore_custom_actions?(route)
-          api_path = "#{OasRails.config.api_path.sub(%r{\A/}, '')}/".sub(%r{/+$}, '/')
-          ignored_actions = OasRails.config.ignored_actions.flat_map do |custom_route|
+        def ignore_custom_actions?(route, config:)
+          api_path = "#{config.api_path.sub(%r{\A/}, '')}/".sub(%r{/+$}, '/')
+          ignored_actions = config.ignored_actions.flat_map do |custom_route|
             if custom_route.start_with?(api_path)
               [custom_route]
             else

--- a/test/controllers/oas_rails/oas_rails_controller_test.rb
+++ b/test/controllers/oas_rails/oas_rails_controller_test.rb
@@ -4,13 +4,23 @@ module OasRails
   class OasRailsControllerTest < ActionDispatch::IntegrationTest
     include Engine.routes.url_helpers
 
-    test 'should return the front' do
-      get '/docs'
+    test 'should return public docs' do
+      get '/api/docs'
       assert_response :ok
     end
 
-    test 'should return the oas' do
-      get '/docs.json'
+    test 'should return public oas docs' do
+      get '/api/docs.json'
+      assert_response :ok
+    end
+
+    test 'should return internal docs' do
+      get '/internal/api/docs'
+      assert_response :ok
+    end
+
+    test 'should return internal oas docs' do
+      get '/internal/api/docs.json'
       assert_response :ok
     end
   end

--- a/test/dummy/README_OAS.md
+++ b/test/dummy/README_OAS.md
@@ -1,0 +1,51 @@
+This dummy app demonstrates mounting the OasRails engine multiple times with separate configurations.
+
+Mount points (configured in `config/routes.rb`):
+
+- `/api/docs` -> public configuration (configuration: 'public')
+- `/internal/api/docs` -> internal configuration (configuration: 'internal')
+
+How this experiment is set up:
+
+- Two models were created: `Post` and `Comment` (comments belong to posts).
+- Controllers with basic JSON endpoints:
+  - `PostsController` (index, show, create, update, destroy) — tag: `Posts`
+  - `CommentsController` (create, destroy) nested under posts — tag: `Comments`
+  - `Admin::ReportsController` (index) returning counts and recent posts — tag: `Admin` (internal)
+  - Existing controllers with tags: `Users` (`UsersController`), `Projects` (`ProjectsController`), `Typed` (`TypedController`), `Users::Avatar` (`Users::AvatarController`)
+- Two OAS configurations are declared in `config/initializers/oas_rails.rb`
+
+Quick usage examples (using `curl`):
+
+- Create a post:
+  curl -X POST -H "Content-Type: application/json" -d '{"post": {"title": "Hello","body": "World","published": true}}' http://localhost:3000/posts
+
+- Create a comment on post 1:
+  curl -X POST -H "Content-Type: application/json" -d '{"comment": {"body": "Nice post","user": "bob"}}' http://localhost:3000/posts/1/comments
+
+- List posts:
+  curl http://localhost:3000/posts
+
+- Admin reports (internal):
+  curl http://localhost:3000/admin/reports
+
+- View public docs:
+  http://localhost:3000/api/docs
+
+- View internal docs:
+  http://localhost:3000/internal/api/docs
+
+Notes:
+- The OasRails engine must support the `default: { configuration: 'name' }` mount option. The initializer sets up two named configurations (`:public` and `:internal`).
+- Controller actions include YARD tags such as `@summary`, `@tags`, `@parameter`, `@request_body`, and `@response` that OasRails can use to enrich the generated OpenAPI document. Example tags used in this dummy app:
+  - `Users` — user-related endpoints (login, create, update, delete)
+  - `Projects` — project management
+  - `Typed` — typed endpoints used for testing Sorbet integration
+  - `Posts` — public posts API (added in this experiment)
+  - `Comments` — nested comments for posts
+  - `Admin` — internal admin/operational endpoints (only in internal config)
+
+If you want, I can:
+- Add component schema YARD comments to `Post` and `Comment` models so OasRails will generate component schemas for them.
+- Add request specs to validate that each mount serves a different configuration.
+- Extend tags and operation descriptions with examples and response schemas.

--- a/test/dummy/app/controllers/admin/reports_controller.rb
+++ b/test/dummy/app/controllers/admin/reports_controller.rb
@@ -1,0 +1,12 @@
+class Admin::ReportsController < ApplicationController
+  # @summary Administrative reports and counts
+  # @tags Admin
+  # @response Report(200) [Hash{ posts_count: Integer, comments_count: Integer, recent_posts: Array<String> }]
+  def index
+    render json: {
+      posts_count: Post.count,
+      comments_count: Comment.count,
+      recent_posts: Post.order(created_at: :desc).limit(5).pluck(:id, :title)
+    }
+  end
+end

--- a/test/dummy/app/controllers/comments_controller.rb
+++ b/test/dummy/app/controllers/comments_controller.rb
@@ -1,0 +1,42 @@
+class CommentsController < ApplicationController
+  before_action :set_post
+  before_action :set_comment, only: [:destroy]
+
+  # @summary Create a comment for a post
+  # @tags Comments
+  # @parameter post_id(path) [!Integer] The post ID
+  # @request_body Comment to create [Hash{ body: String, user: String }]
+  # @response Comment created(201) [Reference:#/components/schemas/Comment]
+  def create
+    @comment = @post.comments.build(comment_params)
+    if @comment.save
+      render json: @comment, status: :created
+    else
+      render json: { errors: @comment.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  # @summary Delete a comment
+  # @tags Comments
+  # @parameter post_id(path) [!Integer] The post ID
+  # @parameter id(path) [!Integer] The comment ID
+  # @response No content(204) [Hash{body: String}]
+  def destroy
+    @comment.destroy
+    head :no_content
+  end
+
+  private
+
+  def set_post
+    @post = Post.find(params[:post_id])
+  end
+
+  def set_comment
+    @comment = @post.comments.find(params[:id])
+  end
+
+  def comment_params
+    params.require(:comment).permit(:body, :user)
+  end
+end

--- a/test/dummy/app/controllers/posts_controller.rb
+++ b/test/dummy/app/controllers/posts_controller.rb
@@ -1,0 +1,65 @@
+class PostsController < ApplicationController
+  before_action :set_post, only: [:show, :update, :destroy]
+
+  # @summary List posts
+  # @tags Posts
+  # @response Posts list(200) [Array<Post>]
+  def index
+    @posts = Post.all
+    render json: @posts
+  end
+
+  # @summary Show a post by id
+  # @tags Posts
+  # @parameter id(path) [!Integer] The post ID
+  # @response A post(200) [Reference:#/components/schemas/Post]
+  # @response Post not found(404) [Hash{message: String}]
+  def show
+    render json: @post
+  end
+
+  # @summary Create a new post
+  # @tags Posts
+  # @request_body Post to create [Reference:#/components/schemas/Post]
+  # @response Post created(201) [Reference:#/components/schemas/Post]
+  def create
+    @post = Post.new(post_params)
+    if @post.save
+      render json: @post, status: :created
+    else
+      render json: { errors: @post.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  # @summary Update a post
+  # @tags Posts
+  # @parameter id(path) [!Integer] The post ID
+  # @request_body Post to update [Reference:#/components/schemas/Post]
+  # @response Updated post(200) [Reference:#/components/schemas/Post]
+  def update
+    if @post.update(post_params)
+      render json: @post
+    else
+      render json: { errors: @post.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  # @summary Delete a post
+  # @tags Posts
+  # @parameter id(path) [!Integer] The post ID
+  # @response No content(204) []
+  def destroy
+    @post.destroy
+    head :no_content
+  end
+
+  private
+
+  def set_post
+    @post = Post.find(params[:id])
+  end
+
+  def post_params
+    params.require(:post).permit(:title, :body, :published)
+  end
+end

--- a/test/dummy/app/controllers/projects_controller.rb
+++ b/test/dummy/app/controllers/projects_controller.rb
@@ -2,7 +2,7 @@
 class ProjectsController < ApplicationController
   before_action :set_project, only: %i[show update destroy]
 
-  # @tags projects
+  # @tags Projects
   def index
     @projects = Project.all
 
@@ -13,7 +13,7 @@ class ProjectsController < ApplicationController
     render json: @project
   end
 
-  # @tags projects
+  # @tags Projects
   def create
     @project = Project.new(project_params)
 

--- a/test/dummy/app/controllers/users/avatar_controller.rb
+++ b/test/dummy/app/controllers/users/avatar_controller.rb
@@ -6,7 +6,7 @@ module Users
     before_action :set_user
 
     # @summary Upload an avatar
-    # @tags 3. Third
+    # @tags Users
     #
     # Uploads an avatar for the user. The avatar must be a valid image file (JPEG, PNG, GIF, SVG or WEBP).
     # @request_body Avatar Image (multipart/form-data) [!Hash{avatar: !File}]

--- a/test/dummy/app/controllers/users_controller.rb
+++ b/test/dummy/app/controllers/users_controller.rb
@@ -76,7 +76,7 @@ class UsersController < ApplicationController
 
   # @summary Create a User New
   # @no_auth
-  # @tags 1. First
+  # @tags Users
   #
   # Invite a user to an organization.
   #
@@ -105,7 +105,7 @@ class UsersController < ApplicationController
   end
 
   # Update a user.
-  # @tags 2. Second
+  # @tags Users, Update
   # A `user` can be updated with this method
   # - There is no option
   # - It must work

--- a/test/dummy/app/models/comment.rb
+++ b/test/dummy/app/models/comment.rb
@@ -1,0 +1,3 @@
+class Comment < ApplicationRecord
+  belongs_to :post
+end

--- a/test/dummy/app/models/post.rb
+++ b/test/dummy/app/models/post.rb
@@ -1,0 +1,4 @@
+class Post < ApplicationRecord
+  has_many :comments, dependent: :destroy
+  validates :title, presence: true
+end

--- a/test/dummy/config/initializers/oas_rails.rb
+++ b/test/dummy/config/initializers/oas_rails.rb
@@ -1,48 +1,106 @@
-OasRails.configure do |config|
-  config.source_oas_path = "lib/oas.json"
-  config.info.title = 'Dummy API REST+'
-  config.info.summary = 'Core endpoints of Dummy App.'
+# Configure two separate OAS Rails instances for testing mounting the engine multiple times
+# This file provides two named configurations: :public and :internal
+# Use `mount OasRails::Engine => '/path', default: { configuration: 'name' }` to mount each one.
+
+# Public configuration - intended for external documentation
+OasRails.configure(:public) do |config|
+  # Basic Information about the API
+  config.info.title = 'Dummy App Public API'
+  config.info.version = '1.0.0'
+  config.info.summary = 'Public-facing API for the Dummy app.'
   config.info.description = <<~HEREDOC
-    # Adimuntque regni fuerit
+    This documentation exposes the public endpoints of the Dummy app. It is intended
+    for external developers and clients who consume the public API surface.
 
-    ## Et fuissem licet in vetus hic Rhoetus
-
-    Lorem markdownum currus praetemptanda vocato Canens Tartara. Chaonius demitteret
-    quem **patulas pares decimae** refluum, honores: ullis nec in iunctas, ora
-    fratri saeve, vix.
-
-    ## Etenim habebat sinistra
-
-    Docs: <https://a-chacon.com/oas_rails/>
-
-    Teneri celebrant prius! Dedit non culmine, est duorum apertum dicione edere, ibi
-    cetera Olenos quae: solita.
-
-    - Boum alas malis miranti deum
-    - Victricia ipse
-    - Resque velle in adiere Phrygiae fortis postquam
-    - Remisso agit nobis
-    - Cyclopis superata ingentibus numquam Lucifero
+    The documentation is automatically generated from routes and controller YARD tags
+    and can be mounted at `/api/docs` in this dummy application.
   HEREDOC
-  config.info.contact.name = 'Peter'
-  config.info.contact.email = 'peter@gmail.com'
-  config.info.contact.url = 'https://peter.com'
-  config.servers = [{ url: 'http://localhost:3000', description: 'Local' },
-                    { url: 'https://example.rb', description: 'Dev' }]
-  config.tags = [{ name: "Users", description: "Manage the `amazing` Users table." }]
+  config.info.contact.name = 'Dummy Maintainer'
+  config.info.contact.email = 'maintainer@example.com'
+  config.info.contact.url = 'https://example.com'
+  config.info.license.name = 'MIT'
+  config.info.license.url = 'https://opensource.org/licenses/MIT'
 
+  # Servers Information
+  config.servers = [
+    { url: 'http://localhost:3000', description: 'Local development' },
+    { url: 'https://staging.example.com', description: 'Staging' }
+  ]
+
+  # Tags used to group endpoints (mirrors tags used in controllers)
+  config.tags = [
+    { name: 'Users', description: 'Operations to manage users (login, create, update, delete).' },
+    { name: 'Projects', description: 'Manage projects belonging to users.' },
+    { name: 'Typed', description: 'Small typed example endpoints used to test Sorbet integration.' },
+    { name: 'Posts', description: 'Public blog-like posts endpoints.' },
+    { name: 'Comments', description: 'Manage comments nested under posts.' }
+  ]
+
+  # Authentication defaults
+  config.authenticate_all_routes_by_default = true
   config.security_schema = :bearer
-  # config.security_schemas = {
-  # }
-  #
+  config.security_schemas = {
+    bearer: {
+      "type" => "http",
+      "scheme" => "bearer",
+      "bearerFormat" => "JWT",
+      "description" => "JWT based authentication. Provide as `Authorization: Bearer <token>`"
+    }
+  }
 
-  # Default Errors
-  # The default errors are setted only if the action allow it.
-  # Example, forbidden will be setted to the endpoint requires authentication.
-  # Example: not_found will be setter to the endpoint only if the operation is a show/update/destroy action.
+  # Default error responses to be included where applicable
   config.set_default_responses = true
-  # config.possible_default_responses = [:not_found, :unauthorized, :forbidden]
-  # config.response_body_of_default = "Hash{ message: String, errors: Array<String> }"
+  config.possible_default_responses = [:not_found, :unauthorized, :forbidden, :internal_server_error, :unprocessable_entity]
+  config.response_body_of_default = "Hash{ message: String }"
   config.response_body_of_unauthorized = "Hash{ message: String, error: Array<String> }"
+  config.response_body_of_unprocessable_entity = "Hash{ errors: Array<String> }"
+
+  config.ignored_actions = ["admin/reports"]
+end
+
+# Internal configuration - intended for internal docs / private APIs
+OasRails.configure(:internal) do |config|
+  config.info.title = 'Dummy App Internal API'
+  config.info.version = '1.0.0-internal'
+  config.info.summary = 'Internal API for developers and platform operators.'
+  config.info.description = <<~HEREDOC
+    Internal documentation contains private endpoints and operational APIs that
+    should not be publicly exposed. This configuration is mounted at `/internal/api/docs`.
+  HEREDOC
+  config.info.contact.name = 'Platform Team'
+  config.info.contact.email = 'platform@example.com'
+
+  # Servers for internal environment
+  config.servers = [
+    { url: 'http://localhost:3000', description: 'Local development' },
+    { url: 'https://internal.example.com', description: 'Internal staging' }
+  ]
+
+  # Internal tags (include admin and operational endpoints)
+  config.tags = [
+    { name: 'Admin', description: 'Administrative endpoints and operational reports.' },
+    { name: 'Users', description: 'User management (internal view).' },
+    { name: 'Projects', description: 'Project management (internal view).' },
+    { name: 'Posts', description: 'Posts internal operations.' },
+    { name: 'Comments', description: 'Comments internal operations.' }
+  ]
+
+  # Internal APIs often use API keys or other internal auth. Keep defaults permissive here.
+  config.authenticate_all_routes_by_default = false
+  config.security_schema = :api_key_header
+  config.security_schemas = {
+    api_key_header: {
+      "type" => "apiKey",
+      "in" => "header",
+      "name" => "X-Internal-Api-Key",
+      "description" => "Internal API key header"
+    }
+  }
+
+  config.set_default_responses = true
+  config.possible_default_responses = [:not_found, :unauthorized, :forbidden, :internal_server_error, :unprocessable_entity]
+  config.response_body_of_default = "Hash{ message: String }"
   config.response_body_of_internal_server_error = "Hash{ error: String, traceback: String }"
+
+  config.api_path = "/admin"
 end

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,11 +1,25 @@
 Rails.application.routes.draw do
   post '/users/login', to: 'users#login'
   get "/users/new", to: "users#new" # This route is for testing purpose
+
   resources :users, shallow: true do
     resources :projects
     resource :avatar, only: [:update], controller: 'users/avatar'
   end
+
   match 'users', to: 'users#index', via: [:get, :options]
   resources :typed, only: [:index, :show]
-  mount OasRails::Engine => '/docs'
+
+  # Example resources for the experimental API used to test multiple OAS mounts
+  resources :posts do
+    resources :comments, only: [:create, :destroy]
+  end
+
+  namespace :admin do
+    resources :reports, only: [:index]
+  end
+
+  # Mount the OasRails engine twice with different configurations
+  mount OasRails::Engine => '/api/docs', default: { configuration: 'public' }, as: 'public_oas'
+  mount OasRails::Engine => '/internal/api/docs', default: { configuration: 'internal' }, as: 'internal_oas'
 end

--- a/test/dummy/db/migrate/20260518202040_create_posts.rb
+++ b/test/dummy/db/migrate/20260518202040_create_posts.rb
@@ -1,0 +1,11 @@
+class CreatePosts < ActiveRecord::Migration[8.1]
+  def change
+    create_table :posts do |t|
+      t.string :title
+      t.text :body
+      t.boolean :published
+
+      t.timestamps
+    end
+  end
+end

--- a/test/dummy/db/migrate/20260518202041_create_comments.rb
+++ b/test/dummy/db/migrate/20260518202041_create_comments.rb
@@ -1,0 +1,11 @@
+class CreateComments < ActiveRecord::Migration[8.1]
+  def change
+    create_table :comments do |t|
+      t.references :post, null: false, foreign_key: true
+      t.text :body
+      t.string :user
+
+      t.timestamps
+    end
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,26 +10,26 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_05_28_212011) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_18_202041) do
   create_table "active_storage_attachments", force: :cascade do |t|
-    t.string "name", null: false
-    t.string "record_type", null: false
-    t.bigint "record_id", null: false
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.bigint "record_id", null: false
+    t.string "record_type", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
   create_table "active_storage_blobs", force: :cascade do |t|
-    t.string "key", null: false
-    t.string "filename", null: false
-    t.string "content_type"
-    t.text "metadata"
-    t.string "service_name", null: false
     t.bigint "byte_size", null: false
     t.string "checksum"
+    t.string "content_type"
     t.datetime "created_at", null: false
+    t.string "filename", null: false
+    t.string "key", null: false
+    t.text "metadata"
+    t.string "service_name", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
@@ -39,30 +39,48 @@ ActiveRecord::Schema[7.0].define(version: 2025_05_28_212011) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
-  create_table "projects", force: :cascade do |t|
-    t.string "name"
-    t.text "description"
-    t.integer "user_id", null: false
+  create_table "comments", force: :cascade do |t|
+    t.text "body"
     t.datetime "created_at", null: false
+    t.integer "post_id", null: false
     t.datetime "updated_at", null: false
+    t.string "user"
+    t.index ["post_id"], name: "index_comments_on_post_id"
+  end
+
+  create_table "posts", force: :cascade do |t|
+    t.text "body"
+    t.datetime "created_at", null: false
+    t.boolean "published"
+    t.string "title"
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "projects", force: :cascade do |t|
     t.boolean "active", default: false
-    t.date "start_date"
-    t.datetime "end_date"
     t.decimal "budget", precision: 10, scale: 2
+    t.datetime "created_at", null: false
+    t.text "description"
+    t.datetime "end_date"
+    t.string "name"
     t.integer "priority"
+    t.date "start_date"
     t.string "status", default: "draft"
+    t.datetime "updated_at", null: false
+    t.integer "user_id", null: false
     t.index ["user_id"], name: "index_projects_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
-    t.string "name"
-    t.string "email"
-    t.string "password_digest"
     t.datetime "created_at", null: false
+    t.string "email"
+    t.string "name"
+    t.string "password_digest"
     t.datetime "updated_at", null: false
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "comments", "posts"
   add_foreign_key "projects", "users"
 end

--- a/test/dummy/test/controllers/admin/reports_controller_test.rb
+++ b/test/dummy/test/controllers/admin/reports_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class Admin::ReportsControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get admin_reports_index_url
+    assert_response :success
+  end
+end

--- a/test/dummy/test/controllers/comments_controller_test.rb
+++ b/test/dummy/test/controllers/comments_controller_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class CommentsControllerTest < ActionDispatch::IntegrationTest
+  test "should get create" do
+    get comments_create_url
+    assert_response :success
+  end
+
+  test "should get destroy" do
+    get comments_destroy_url
+    assert_response :success
+  end
+end

--- a/test/dummy/test/controllers/posts_controller_test.rb
+++ b/test/dummy/test/controllers/posts_controller_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+
+class PostsControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get posts_index_url
+    assert_response :success
+  end
+
+  test "should get show" do
+    get posts_show_url
+    assert_response :success
+  end
+
+  test "should get create" do
+    get posts_create_url
+    assert_response :success
+  end
+
+  test "should get update" do
+    get posts_update_url
+    assert_response :success
+  end
+
+  test "should get destroy" do
+    get posts_destroy_url
+    assert_response :success
+  end
+end

--- a/test/dummy/test/factories/comments.rb
+++ b/test/dummy/test/factories/comments.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :comment do
+    post { nil }
+    body { "MyText" }
+    user { "MyString" }
+  end
+end

--- a/test/dummy/test/factories/posts.rb
+++ b/test/dummy/test/factories/posts.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :post do
+    title { "MyString" }
+    body { "MyText" }
+    published { false }
+  end
+end

--- a/test/dummy/test/models/comment_test.rb
+++ b/test/dummy/test/models/comment_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CommentTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/dummy/test/models/post_test.rb
+++ b/test/dummy/test/models/post_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class PostTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/lib/oas_rails/builders/oas_route_builder_test.rb
+++ b/test/lib/oas_rails/builders/oas_route_builder_test.rb
@@ -11,37 +11,37 @@ module OasRails
       end
 
       def test_build_returns_an_oas_route_object
-        users_index_oas_route = OasRouteBuilder.build_from_rails_route(@users_index_route)
+        users_index_oas_route = OasRouteBuilder.build_from_rails_route(@users_index_route, config: OasRails.config)
         assert_instance_of ::OasCore::OasRoute, users_index_oas_route
       end
 
       def test_build_sets_correct_controller
-        users_index_oas_route = OasRouteBuilder.build_from_rails_route(@users_index_route)
+        users_index_oas_route = OasRouteBuilder.build_from_rails_route(@users_index_route, config: OasRails.config)
         assert_equal "users", users_index_oas_route.controller
       end
 
       def test_build_sets_correct_method
-        users_index_oas_route = OasRouteBuilder.build_from_rails_route(@users_index_route)
+        users_index_oas_route = OasRouteBuilder.build_from_rails_route(@users_index_route, config: OasRails.config)
         assert_equal "index", users_index_oas_route.method_name
       end
 
       def test_build_sets_correct_verb
-        users_index_oas_route = OasRouteBuilder.build_from_rails_route(@users_index_route)
+        users_index_oas_route = OasRouteBuilder.build_from_rails_route(@users_index_route, config: OasRails.config)
         assert_equal "GET", users_index_oas_route.verb
       end
 
       def test_build_sets_correct_path
-        users_index_oas_route = OasRouteBuilder.build_from_rails_route(@users_index_route)
+        users_index_oas_route = OasRouteBuilder.build_from_rails_route(@users_index_route, config: OasRails.config)
         assert_equal "/users", users_index_oas_route.path
       end
 
       def test_build_sets_correct_docstring
-        users_index_oas_route = OasRouteBuilder.build_from_rails_route(@users_index_route)
+        users_index_oas_route = OasRouteBuilder.build_from_rails_route(@users_index_route, config: OasRails.config)
         assert_not_nil users_index_oas_route.docstring
       end
 
       def test_docstring_blank_comment_lines_produce_paragraph_breaks
-        oas_route = OasRouteBuilder.build_from_rails_route(@users_create_route)
+        oas_route = OasRouteBuilder.build_from_rails_route(@users_create_route, config: OasRails.config)
         docstring_text = oas_route.docstring.to_s
 
         # The comment contains a bare `#` line between "Invite a user..." and
@@ -54,12 +54,12 @@ module OasRails
       end
 
       def test_build_sets_correct_source_string
-        users_index_oas_route = OasRouteBuilder.build_from_rails_route(@users_index_route)
+        users_index_oas_route = OasRouteBuilder.build_from_rails_route(@users_index_route, config: OasRails.config)
         assert_not_nil users_index_oas_route.source_string
       end
 
       def test_build_sets_correct_tags
-        users_index_oas_route = OasRouteBuilder.build_from_rails_route(@projects_show_route)
+        users_index_oas_route = OasRouteBuilder.build_from_rails_route(@projects_show_route, config: OasRails.config)
         assert_not_nil users_index_oas_route.tags
         assert(users_index_oas_route.tags.all? { |tag| tag.respond_to?(:tag_name) })
       end
@@ -67,40 +67,40 @@ module OasRails
       # Tests for Sorbet runtime-wrapper compatibility
 
       def test_wrapped_by_runtime_returns_false_for_unwrapped_method
-        builder = OasRouteBuilder.new(@users_index_route)
+        builder = OasRouteBuilder.new(@users_index_route, config: OasRails.config)
         unbound = UsersController.instance_method(:index)
         refute builder.send(:wrapped_by_runtime?, unbound)
       end
 
       def test_wrapped_by_runtime_returns_true_for_sorbet_wrapped_method
-        builder = OasRouteBuilder.new(@typed_index_route)
+        builder = OasRouteBuilder.new(@typed_index_route, config: OasRails.config)
         unbound = TypedController.instance_method(:index)
         assert builder.send(:wrapped_by_runtime?, unbound)
       end
 
       def test_method_comment_safe_returns_annotations_for_unwrapped_method
-        builder = OasRouteBuilder.new(@users_index_route)
+        builder = OasRouteBuilder.new(@users_index_route, config: OasRails.config)
         comment = builder.send(:method_comment_safe)
         assert_includes comment, "@parameter offset(query)"
         assert_includes comment, "@response Users list"
       end
 
       def test_method_comment_safe_returns_annotations_for_sorbet_wrapped_method
-        builder = OasRouteBuilder.new(@typed_index_route)
+        builder = OasRouteBuilder.new(@typed_index_route, config: OasRails.config)
         comment = builder.send(:method_comment_safe)
         assert_includes comment, "@summary List typed items"
         assert_includes comment, "@response Typed items list"
       end
 
       def test_class_comment_safe_returns_class_annotations_for_sorbet_wrapped_method
-        builder = OasRouteBuilder.new(@typed_index_route)
+        builder = OasRouteBuilder.new(@typed_index_route, config: OasRails.config)
         comment = builder.send(:class_comment_safe)
         assert_includes comment, "@tags Typed"
         assert_includes comment, "Typed Items API"
       end
 
       def test_build_works_for_sorbet_wrapped_controller
-        oas_route = OasRouteBuilder.build_from_rails_route(@typed_index_route)
+        oas_route = OasRouteBuilder.build_from_rails_route(@typed_index_route, config: OasRails.config)
         assert_instance_of ::OasCore::OasRoute, oas_route
         assert_equal "typed", oas_route.controller
         assert_equal "index", oas_route.method_name

--- a/test/lib/oas_rails/extractors/route_extractor_test.rb
+++ b/test/lib/oas_rails/extractors/route_extractor_test.rb
@@ -2,46 +2,46 @@ module OasRails
   module Builders
     class RouteExtractorTest < Minitest::Test
       def setup
-        Extractors::RouteExtractor.clear_cache
+        Extractors::RouteExtractor.clear_cache(config: OasRails.config)
         OasRails.config.ignored_actions = []
         OasRails.config.include_mode = :all
       end
 
       def teardown
-        Extractors::RouteExtractor.clear_cache
+        Extractors::RouteExtractor.clear_cache(config: OasRails.config)
         OasRails.config.ignored_actions = []
         OasRails.config.include_mode = :all
       end
 
       def test_without_custom_routes
-        result = Extractors::RouteExtractor.host_routes
+        result = Extractors::RouteExtractor.host_routes(config: OasRails.config)
         assert_equal 18, result.count
       end
 
       def test_with_custom_controllers_actions
-        init_count = Extractors::RouteExtractor.host_routes.count
+        init_count = Extractors::RouteExtractor.host_routes(config: OasRails.config).count
         OasRails.config.ignored_actions = ["projects#index"]
-        Extractors::RouteExtractor.clear_cache
-        result = Extractors::RouteExtractor.host_routes.count
+        Extractors::RouteExtractor.clear_cache(config: OasRails.config)
+        result = Extractors::RouteExtractor.host_routes(config: OasRails.config).count
         assert_equal (init_count - 1), result
       end
 
       def test_with_custom_controller_only
         OasRails.config.ignored_actions = ["projects"]
-        routes = Extractors::RouteExtractor.host_routes
+        routes = Extractors::RouteExtractor.host_routes(config: OasRails.config)
         result = routes.select { |route| route.controller.include?("projects") }
         assert_equal 0, result.count
       end
 
       def test_extract_host_routes_with_tags_mode
         OasRails.config.include_mode = :with_tags
-        result = Extractors::RouteExtractor.host_routes
+        result = Extractors::RouteExtractor.host_routes(config: OasRails.config)
         assert_equal 14, result.count
       end
 
       def test_extract_host_routes_explicit_mode
         OasRails.config.include_mode = :explicit
-        result = Extractors::RouteExtractor.host_routes
+        result = Extractors::RouteExtractor.host_routes(config: OasRails.config)
         assert_equal 1, result.count
       end
     end

--- a/test/lib/oas_rails/extractors/route_extractor_test.rb
+++ b/test/lib/oas_rails/extractors/route_extractor_test.rb
@@ -15,7 +15,7 @@ module OasRails
 
       def test_without_custom_routes
         result = Extractors::RouteExtractor.host_routes(config: OasRails.config)
-        assert_equal 18, result.count
+        assert_equal 27, result.count
       end
 
       def test_with_custom_controllers_actions
@@ -36,7 +36,7 @@ module OasRails
       def test_extract_host_routes_with_tags_mode
         OasRails.config.include_mode = :with_tags
         result = Extractors::RouteExtractor.host_routes(config: OasRails.config)
-        assert_equal 14, result.count
+        assert_equal 23, result.count
       end
 
       def test_extract_host_routes_explicit_mode

--- a/test/oas_rails_test.rb
+++ b/test/oas_rails_test.rb
@@ -7,7 +7,7 @@ class OasRailsTest < ActiveSupport::TestCase
 
   class MockRouteExtractor < OasRails::Extractors::RouteExtractor
     def self.host_routes(config:)
-      super(config:).select { |route| route.controller.include?("users") }
+      super.select { |route| route.controller.include?("users") }
     end
   end
 

--- a/test/oas_rails_test.rb
+++ b/test/oas_rails_test.rb
@@ -6,8 +6,8 @@ class OasRailsTest < ActiveSupport::TestCase
   end
 
   class MockRouteExtractor < OasRails::Extractors::RouteExtractor
-    def self.host_routes
-      super.select { |route| route.controller.include?("users") }
+    def self.host_routes(config:)
+      super(config:).select { |route| route.controller.include?("users") }
     end
   end
 
@@ -16,7 +16,7 @@ class OasRailsTest < ActiveSupport::TestCase
     config.route_extractor = MockRouteExtractor
 
     OasRails.stub(:config, config) do
-      custom_routes = OasRails.config.route_extractor.host_routes
+      custom_routes = OasRails.config.route_extractor.host_routes(config: OasRails.config)
       assert custom_routes.all? { |route| route.controller.include?("users") }, "Expected to get user routes only"
 
       oas_core_mock = Minitest::Mock.new


### PR DESCRIPTION
closes #177 

I need to test it a bit more, but looks like this:

1. Configure

```
# /config/intializers/oas_rails.rb
OasRail.configure(:public) do
 ...configs
end

OasRail.configure(:internal) do
 ...configs
end
```
2. Mount using any of the defined configurations:

```
  mount OasRails::Engine => '/api/docs', default: { configuration: 'public' }, as: 'public'
  mount OasRails::Engine => '/internal/api/docs', default: { configuration: 'internal' }, as: 'internal'
```

So, we can define multiple configurations and multiple mount points.